### PR TITLE
[PW-15] 실종동물 북마크 및 북마크 조회 api 구현

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/favorites/presentation/FavoritesController.java
+++ b/src/main/java/kr/co/pawong/pwbe/favorites/presentation/FavoritesController.java
@@ -12,28 +12,16 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/api/users/me/favorites")
+@RequestMapping("/api/users/favorites")
 @RequiredArgsConstructor
 public class FavoritesController {
 
     private final FavoritesService favoritesService;
 
     /**
-     * 현재 로그인된 유저가 찜 목록을 받아오는 API
-     */
-    @GetMapping("")
-    public ResponseEntity<FavoritesListResponse> getFavorites(
-            @AuthenticationPrincipal CustomUserDetails principal
-    ) {
-        Long userId = principal.getUserId();
-        FavoritesListResponse response = favoritesService.findAllByUserId(userId);   // favorites가 도메인명이므로 favoritesList로 네이밍
-        return ResponseEntity.ok(response);
-    }
-
-    /**
      * 현재 로그인된 유저가 adoption 공고를 토글 방식으로 찜하는 API
      */
-    @PostMapping("/{adoptionId}")
+    @PostMapping("/{adoptionId}/toggle")
     public ResponseEntity<FavoritesResponse> toggleFavorite(
             @PathVariable Long adoptionId,
             @AuthenticationPrincipal CustomUserDetails principal

--- a/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
@@ -16,6 +16,7 @@ public enum CustomErrorCode implements ErrorCode {
      * 400 BAD_REQUEST
      */
     REQUEST_ERROR(BAD_REQUEST, "입력값이 잘못되었습니다."),
+    LOST_ANIMAL_TYPE_MISSING_ERROR(BAD_REQUEST, "실종 동물 타입이 필요합니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
@@ -16,7 +16,6 @@ public enum CustomErrorCode implements ErrorCode {
      * 400 BAD_REQUEST
      */
     REQUEST_ERROR(BAD_REQUEST, "입력값이 잘못되었습니다."),
-    LOST_ANIMAL_TYPE_MISSING_ERROR(BAD_REQUEST, "실종 동물 타입이 필요합니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/user/BookmarkInfoAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/user/BookmarkInfoAdapter.java
@@ -1,0 +1,24 @@
+package kr.co.pawong.pwbe.lostPost.adapter.out.user;
+
+import kr.co.pawong.pwbe.lostPost.application.port.out.BookmarkInfoPort;
+import kr.co.pawong.pwbe.user.application.port.in.QueryBookmarkDataUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookmarkInfoAdapter implements BookmarkInfoPort {
+
+    private final QueryBookmarkDataUseCase queryBookmarkDataUseCase;
+
+    @Override
+    public boolean existsByUserIdAndLostPostId(Long userId, Long lostPostId) {
+        return queryBookmarkDataUseCase.lostPostBookmarkExists(userId, lostPostId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndAdoptionId(Long userId, Long adoptionId) {
+        return queryBookmarkDataUseCase.lostAdoptionBookmarkExists(userId, adoptionId);
+    }
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/user/UserInfoAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/user/UserInfoAdapter.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.lostPost.adapter.out.user;
 
 import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
+import kr.co.pawong.pwbe.user.application.port.in.QueryBookmarkDataUseCase;
 import kr.co.pawong.pwbe.user.application.port.in.QueryNicknameUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostAnimalDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostAnimalDataUseCase.java
@@ -1,0 +1,10 @@
+package kr.co.pawong.pwbe.lostPost.application.port.in;
+
+import java.util.List;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
+
+public interface QueryLostAnimalDataUseCase {
+
+    List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries);
+}

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostPostDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostPostDataUseCase.java
@@ -1,9 +1,13 @@
 package kr.co.pawong.pwbe.lostPost.application.port.in;
 
 import java.util.List;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
 
 public interface QueryLostPostDataUseCase {
 
     List<LostPostCard> getLostPostsByUserId(Long userId);
+
+    List<LostPostCard> getLostAnimalsByPostIds(List<LostAnimalQuery> lostAnimalQueries);
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostPostDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostPostDataUseCase.java
@@ -11,6 +11,4 @@ public interface QueryLostPostDataUseCase {
 
     LostPostDetailResponse findLostPostById(Long lostPostId);
 
-    List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries);
-
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostPostDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/QueryLostPostDataUseCase.java
@@ -9,8 +9,8 @@ public interface QueryLostPostDataUseCase {
 
     List<LostPostCard> getLostPostsByUserId(Long userId);
 
-    List<LostPostCard> getLostAnimalsByPostIds(List<LostAnimalQuery> lostAnimalQueries);
-
     LostPostDetailResponse findLostPostById(Long lostPostId);
+
+    List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries);
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/dto/LostAnimalQuery.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/dto/LostAnimalQuery.java
@@ -1,0 +1,15 @@
+package kr.co.pawong.pwbe.lostPost.application.port.in.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LostAnimalQuery(
+        LostType type,
+        long id // lostPostId 또는 adoptionId
+) {
+
+    public static enum LostType {
+        LOST_ADOPTION, LOST_POST
+    }
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/dto/LostAnimalQuery.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/dto/LostAnimalQuery.java
@@ -5,10 +5,11 @@ import lombok.Builder;
 @Builder
 public record LostAnimalQuery(
         LostType type,
-        long id // lostPostId 또는 adoptionId
+        long id, // lostPostId 또는 adoptionId
+        long userId
 ) {
 
-    public static enum LostType {
+    public enum LostType {
         LOST_ADOPTION, LOST_POST
     }
 

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
@@ -45,7 +45,7 @@ public class LostPostCardMapper {
                 .author(shelter)
                 .imageUrl(lostAdoption.getPopfile1())
                 .happenedDate(TimeUtils.formatDate(lostAdoption.getHappenDt()))
-                .happenedPlace(null)
+                .happenedPlace(lostAdoption.getHappenPlace())
                 .kindNm(lostAdoption.getKindNm())
                 .createdAt(TimeUtils.formatDateAgo(lostAdoption.getNoticeSdt(), clock))
                 .feature(lostAdoption.getSpecialMark())

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
@@ -17,7 +17,7 @@ public class LostPostCardMapper {
      * @param author   - 작성자 닉네임
      */
     public static LostPostCard toLostPostCard(
-            LostPost lostPost, String author, Clock clock) {
+            LostPost lostPost, String author, boolean bookmarked, Clock clock) {
 
         return LostPostCard.builder()
                 .postId(lostPost.getLostPostId())
@@ -29,6 +29,7 @@ public class LostPostCardMapper {
                 .kindNm(lostPost.getKindNm())
                 .createdAt(TimeUtils.formatTimeAgo(lostPost.getCreatedAt(), clock))
                 .feature(lostPost.getSpecialMark())
+                .bookmarked(bookmarked)
                 .build();
     }
 
@@ -37,7 +38,7 @@ public class LostPostCardMapper {
      * @param shelter   - 작성자 닉네임
      */
     public static LostPostCard toLostPostCard(
-            LostAdoption lostAdoption, String shelter, Clock clock) {
+            LostAdoption lostAdoption, String shelter, boolean bookmarked, Clock clock) {
 
         return LostPostCard.builder()
                 .postId(lostAdoption.getAdoptionId())
@@ -49,6 +50,7 @@ public class LostPostCardMapper {
                 .kindNm(lostAdoption.getKindNm())
                 .createdAt(TimeUtils.formatDateAgo(lostAdoption.getNoticeSdt(), clock))
                 .feature(lostAdoption.getSpecialMark())
+                .bookmarked(bookmarked)
                 .build();
     }
 

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
@@ -34,15 +34,15 @@ public class LostPostCardMapper {
 
     /**
      * @param lostAdoption - 변환할 LostAdoption
-     * @param author   - 작성자 닉네임
+     * @param shelter   - 작성자 닉네임
      */
     public static LostPostCard toLostPostCard(
-            LostAdoption lostAdoption, String author, Clock clock) {
+            LostAdoption lostAdoption, String shelter, Clock clock) {
 
         return LostPostCard.builder()
                 .postId(lostAdoption.getAdoptionId())
                 .postType(PostType.FOSTER.name())
-                .author(author)
+                .author(shelter)
                 .imageUrl(lostAdoption.getPopfile1())
                 .happenedDate(TimeUtils.formatDate(lostAdoption.getHappenDt()))
                 .happenedPlace(null)
@@ -51,4 +51,5 @@ public class LostPostCardMapper {
                 .feature(lostAdoption.getSpecialMark())
                 .build();
     }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
@@ -3,7 +3,9 @@ package kr.co.pawong.pwbe.lostPost.application.port.in.mapper;
 import java.time.Clock;
 import kr.co.pawong.pwbe.global.util.TimeUtils;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
+import kr.co.pawong.pwbe.lostPost.domain.LostAdoption;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
+import kr.co.pawong.pwbe.lostPost.enums.PostType;
 
 /**
  * LostPost 도메인 객체를 LostPostCard_로 변환하는 Mapper_입니다.
@@ -27,6 +29,26 @@ public class LostPostCardMapper {
                 .kindNm(lostPost.getKindNm())
                 .createdAt(TimeUtils.formatTimeAgo(lostPost.getCreatedAt(), clock))
                 .feature(lostPost.getSpecialMark())
+                .build();
+    }
+
+    /**
+     * @param lostAdoption - 변환할 LostAdoption
+     * @param author   - 작성자 닉네임
+     */
+    public static LostPostCard toLostPostCard(
+            LostAdoption lostAdoption, String author, Clock clock) {
+
+        return LostPostCard.builder()
+                .postId(lostAdoption.getAdoptionId())
+                .postType(PostType.FOSTER.name())
+                .author(author)
+                .imageUrl(lostAdoption.getPopfile1())
+                .happenedDate(TimeUtils.formatDate(lostAdoption.getHappenDt()))
+                .happenedPlace(null)
+                .kindNm(lostAdoption.getKindNm())
+                .createdAt(TimeUtils.formatDateAgo(lostAdoption.getNoticeSdt(), clock))
+                .feature(lostAdoption.getSpecialMark())
                 .build();
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/BookmarkInfoPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/BookmarkInfoPort.java
@@ -1,0 +1,9 @@
+package kr.co.pawong.pwbe.lostPost.application.port.out;
+
+public interface BookmarkInfoPort {
+
+    boolean existsByUserIdAndLostPostId(Long userId, Long lostPostId);
+
+    boolean existsByUserIdAndAdoptionId(Long userId, Long adoptionId);
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
@@ -6,6 +6,7 @@ import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostAnimalDataUseCase
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
+import kr.co.pawong.pwbe.lostPost.application.port.out.BookmarkInfoPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostAdoptionDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.ShelterCareNmPort;
@@ -24,6 +25,7 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
     private final LostPostDataQueryPort lostPostDataQueryPort;
     private final ShelterCareNmPort shelterCareNmPort;
     private final UserInfoPort userInfoPort;
+    private final BookmarkInfoPort bookmarkInfoPort;
     private final Clock clock;
 
     @Override
@@ -43,7 +45,10 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
                         lostAnimalQuery.id());
                 // 작성자 이름 조회
                 String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
-                yield LostPostCardMapper.toLostPostCard(lostPost, author, clock);
+                // 유저 북마크 여부
+                boolean bookmarked = bookmarkInfoPort.existsByUserIdAndLostPostId(lostAnimalQuery.userId(),
+                        lostAnimalQuery.id());
+                yield LostPostCardMapper.toLostPostCard(lostPost, author, bookmarked, clock);
             }
             // Lost Adoption 가져오기
             case LOST_ADOPTION -> {
@@ -52,7 +57,10 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
                 // 보호소 이름 조회
                 String shelter = shelterCareNmPort.getShelterCareNmByCareRegNo(
                         lostAdoption.getCareRegNo());
-                yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, clock);
+                // 유저 북마크 여부
+                boolean bookmarked = bookmarkInfoPort.existsByUserIdAndLostPostId(lostAnimalQuery.userId(),
+                        lostAnimalQuery.id());
+                yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, bookmarked, clock);
             }
         };
     }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
@@ -1,0 +1,59 @@
+package kr.co.pawong.pwbe.lostPost.application.service;
+
+import java.time.Clock;
+import java.util.List;
+import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostAnimalDataUseCase;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
+import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
+import kr.co.pawong.pwbe.lostPost.application.port.out.LostAdoptionDataQueryPort;
+import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
+import kr.co.pawong.pwbe.lostPost.application.port.out.ShelterCareNmPort;
+import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
+import kr.co.pawong.pwbe.lostPost.domain.LostAdoption;
+import kr.co.pawong.pwbe.lostPost.domain.LostPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
+
+    private final LostAdoptionDataQueryPort lostAdoptionDataQueryPort;
+    private final LostPostDataQueryPort lostPostDataQueryPort;
+    private final ShelterCareNmPort shelterCareNmPort;
+    private final UserInfoPort userInfoPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries) {
+
+        return lostAnimalQueries.stream()
+                .map(this::convertToLostPostCard)
+                .toList();
+    }
+
+    private LostPostCard convertToLostPostCard(LostAnimalQuery lostAnimalQuery) {
+        return switch (lostAnimalQuery.type()) {
+            // Lost Post 가져오기
+            case LOST_POST -> {
+                LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(
+                        lostAnimalQuery.id());
+                // 작성자 이름 조회
+                String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
+                yield LostPostCardMapper.toLostPostCard(lostPost, author, clock);
+            }
+            // Lost Adoption 가져오기
+            case LOST_ADOPTION -> {
+                LostAdoption lostAdoption = lostAdoptionDataQueryPort.findAdoptionById(
+                        lostAnimalQuery.id());
+                // 보호소 이름 조회
+                String shelter = shelterCareNmPort.getShelterCareNmByCareRegNo(
+                        lostAdoption.getCareRegNo());
+                yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, clock);
+            }
+        };
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
@@ -58,7 +58,7 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
                 String shelter = shelterCareNmPort.getShelterCareNmByCareRegNo(
                         lostAdoption.getCareRegNo());
                 // 유저 북마크 여부
-                boolean bookmarked = bookmarkInfoPort.existsByUserIdAndLostPostId(lostAnimalQuery.userId(),
+                boolean bookmarked = bookmarkInfoPort.existsByUserIdAndAdoptionId(lostAnimalQuery.userId(),
                         lostAnimalQuery.id());
                 yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, bookmarked, clock);
             }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.lostPost.application.service;
 
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.List;
 import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostPostDataUseCase;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
@@ -9,6 +10,7 @@ import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostDetailDto;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostDetailResponse;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostDetailMapper;
+import kr.co.pawong.pwbe.lostPost.application.port.out.LostAdoptionDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QueryLostPostDataService implements QueryLostPostDataUseCase {
 
     private final LostPostDataQueryPort lostPostDataQueryPort;
+    private final LostAdoptionDataQueryPort lostAdoptionDataQueryPort;
     private final UserInfoPort userInfoPort;
     private final Clock clock;
 
@@ -48,7 +51,25 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public List<LostPostCard> getLostAnimalsByPostIds(List<LostAnimalQuery> lostAnimalQueries) {
-        return null;
+    public List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries) {
+        List<LostPostCard> result = new ArrayList<>();
+
+        for (LostAnimalQuery lostAnimalQuery : lostAnimalQueries) {
+            // 이름 얻어오기
+            String author = userInfoPort.getNicknameByUserId(lostAnimalQuery.userId());
+            // 데이터 가져오기
+            result.add(
+                switch (lostAnimalQuery.type()) {
+                    // Lost Post 가져오기
+                    case LOST_POST -> LostPostCardMapper.toLostPostCard(
+                            lostPostDataQueryPort.findLostPostByIdOrThrow(lostAnimalQuery.id()), author, clock);
+                    // Lost Adoption 가져오기
+                    case LOST_ADOPTION -> LostPostCardMapper.toLostPostCard(
+                            lostAdoptionDataQueryPort.findAdoptionById(lostAnimalQuery.id()), author, clock);
+                }
+            );
+        }
+
+        return result;
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
@@ -3,6 +3,7 @@ package kr.co.pawong.pwbe.lostPost.application.service;
 import java.time.Clock;
 import java.util.List;
 import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostPostDataUseCase;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
@@ -30,5 +31,11 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
         return lostPosts.stream()
                 .map(post -> LostPostCardMapper.toLostPostCard(post, author, clock))
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LostPostCard> getLostAnimalsByPostIds(List<LostAnimalQuery> lostAnimalQueries) {
+        return null;
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
@@ -12,7 +12,9 @@ import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostDetailMapper;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostAdoptionDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
+import kr.co.pawong.pwbe.lostPost.application.port.out.ShelterCareNmPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
+import kr.co.pawong.pwbe.lostPost.domain.LostAdoption;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
 
     private final LostPostDataQueryPort lostPostDataQueryPort;
     private final LostAdoptionDataQueryPort lostAdoptionDataQueryPort;
+    private final ShelterCareNmPort shelterCareNmPort;
     private final UserInfoPort userInfoPort;
     private final Clock clock;
 
@@ -55,21 +58,34 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
         List<LostPostCard> result = new ArrayList<>();
 
         for (LostAnimalQuery lostAnimalQuery : lostAnimalQueries) {
-            // 이름 얻어오기
-            String author = userInfoPort.getNicknameByUserId(lostAnimalQuery.userId());
             // 데이터 가져오기
             result.add(
-                switch (lostAnimalQuery.type()) {
-                    // Lost Post 가져오기
-                    case LOST_POST -> LostPostCardMapper.toLostPostCard(
-                            lostPostDataQueryPort.findLostPostByIdOrThrow(lostAnimalQuery.id()), author, clock);
-                    // Lost Adoption 가져오기
-                    case LOST_ADOPTION -> LostPostCardMapper.toLostPostCard(
-                            lostAdoptionDataQueryPort.findAdoptionById(lostAnimalQuery.id()), author, clock);
-                }
+                    convertToLostPostCard(lostAnimalQuery)
             );
         }
 
         return result;
+    }
+
+    private LostPostCard convertToLostPostCard(LostAnimalQuery lostAnimalQuery) {
+        return switch (lostAnimalQuery.type()) {
+            // Lost Post 가져오기
+            case LOST_POST -> {
+                LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(
+                        lostAnimalQuery.id());
+                // 작성자 이름 조회
+                String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
+                yield LostPostCardMapper.toLostPostCard(lostPost, author, clock);
+            }
+            // Lost Adoption 가져오기
+            case LOST_ADOPTION -> {
+                LostAdoption lostAdoption = lostAdoptionDataQueryPort.findAdoptionById(
+                        lostAnimalQuery.id());
+                // 보호소 이름 조회
+                String shelter = shelterCareNmPort.getShelterCareNmByCareRegNo(
+                        lostAdoption.getCareRegNo());
+                yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, clock);
+            }
+        };
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
@@ -3,17 +3,13 @@ package kr.co.pawong.pwbe.lostPost.application.service;
 import java.time.Clock;
 import java.util.List;
 import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostPostDataUseCase;
-import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostDetailDto;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostDetailResponse;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostDetailMapper;
-import kr.co.pawong.pwbe.lostPost.application.port.out.LostAdoptionDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
-import kr.co.pawong.pwbe.lostPost.application.port.out.ShelterCareNmPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
-import kr.co.pawong.pwbe.lostPost.domain.LostAdoption;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,8 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class QueryLostPostDataService implements QueryLostPostDataUseCase {
 
     private final LostPostDataQueryPort lostPostDataQueryPort;
-    private final LostAdoptionDataQueryPort lostAdoptionDataQueryPort;
-    private final ShelterCareNmPort shelterCareNmPort;
     private final UserInfoPort userInfoPort;
     private final Clock clock;
 
@@ -51,34 +45,5 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
         return new LostPostDetailResponse(lostPostDetailDto);
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries) {
 
-        return lostAnimalQueries.stream()
-                .map(this::convertToLostPostCard)
-                .toList();
-    }
-
-    private LostPostCard convertToLostPostCard(LostAnimalQuery lostAnimalQuery) {
-        return switch (lostAnimalQuery.type()) {
-            // Lost Post 가져오기
-            case LOST_POST -> {
-                LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(
-                        lostAnimalQuery.id());
-                // 작성자 이름 조회
-                String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
-                yield LostPostCardMapper.toLostPostCard(lostPost, author, clock);
-            }
-            // Lost Adoption 가져오기
-            case LOST_ADOPTION -> {
-                LostAdoption lostAdoption = lostAdoptionDataQueryPort.findAdoptionById(
-                        lostAnimalQuery.id());
-                // 보호소 이름 조회
-                String shelter = shelterCareNmPort.getShelterCareNmByCareRegNo(
-                        lostAdoption.getCareRegNo());
-                yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, clock);
-            }
-        };
-    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
@@ -8,6 +8,7 @@ import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostDetailDto;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostDetailResponse;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostDetailMapper;
+import kr.co.pawong.pwbe.lostPost.application.port.out.BookmarkInfoPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
@@ -21,6 +22,7 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
 
     private final LostPostDataQueryPort lostPostDataQueryPort;
     private final UserInfoPort userInfoPort;
+    private final BookmarkInfoPort bookmarkInfoPort;
     private final Clock clock;
 
     @Override
@@ -31,7 +33,11 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
         String author = userInfoPort.getNicknameByUserId(userId);
 
         return lostPosts.stream()
-                .map(post -> LostPostCardMapper.toLostPostCard(post, author, clock)).toList();
+                .map(post -> {
+                    boolean bookmarked = bookmarkInfoPort.existsByUserIdAndLostPostId(userId, post.getLostPostId());
+                    return LostPostCardMapper.toLostPostCard(post, author, bookmarked, clock);
+                })
+                .toList();
     }
 
     @Override

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
@@ -1,7 +1,6 @@
 package kr.co.pawong.pwbe.lostPost.application.service;
 
 import java.time.Clock;
-import java.util.ArrayList;
 import java.util.List;
 import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostPostDataUseCase;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
@@ -55,16 +54,10 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
     @Override
     @Transactional(readOnly = true)
     public List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries) {
-        List<LostPostCard> result = new ArrayList<>();
 
-        for (LostAnimalQuery lostAnimalQuery : lostAnimalQueries) {
-            // 데이터 가져오기
-            result.add(
-                    convertToLostPostCard(lostAnimalQuery)
-            );
-        }
-
-        return result;
+        return lostAnimalQueries.stream()
+                .map(this::convertToLostPostCard)
+                .toList();
     }
 
     private LostPostCard convertToLostPostCard(LostAnimalQuery lostAnimalQuery) {

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
@@ -25,4 +25,14 @@ public class BookmarkController {
         boolean bookmarked = toggleBookmarkUseCase.toggleLostPostBookmark(principal.getUserId(), lostPostId);
         return ResponseEntity.ok(new BookmarkResponse(bookmarked));
     }
+
+    @PostMapping("/adoptions/{adoptionId}/toggle")
+    public ResponseEntity<BookmarkResponse> toggleAdoptionPostBookmark(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long adoptionId
+    ) {
+        // 북마크 토글 후 북마크 상태 받아오기
+        boolean bookmarked = toggleBookmarkUseCase.toggleLostAdoptionBookmark(principal.getUserId(), adoptionId);
+        return ResponseEntity.ok(new BookmarkResponse(bookmarked));
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
@@ -18,7 +18,7 @@ public class BookmarkController {
 
     private final ToggleBookmarkUseCase toggleBookmarkUseCase;
 
-    @PostMapping("/lost-animals/{id}/toggle")
+    @PostMapping("/lost-animals/lost-posts/{id}/toggle")
     public ResponseEntity<BookmarkResponse> toggleLostPostsBookmark(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long id

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
@@ -1,7 +1,5 @@
 package kr.co.pawong.pwbe.user.adapter.in.api;
 
-import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.LOST_ANIMAL_TYPE_MISSING_ERROR;
-
 import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.user.adapter.in.api.dto.response.BookmarkResponse;
 import kr.co.pawong.pwbe.user.adapter.out.security.CustomUserDetails;
@@ -21,20 +19,22 @@ public class BookmarkController {
     private final ToggleBookmarkUseCase toggleBookmarkUseCase;
 
     @PostMapping("/lost-animals/{id}/toggle")
-    public ResponseEntity<BookmarkResponse> toggleLostPostBookmark(
-            @RequestParam(required = false) String type,
+    public ResponseEntity<BookmarkResponse> toggleLostPostsBookmark(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long id
     ) {
-        boolean bookmarked;
         // 북마크 토글 후 북마크 상태 받아오기
-        if (type.equals("lost-posts")) {
-            bookmarked = toggleBookmarkUseCase.toggleLostPostBookmark(principal.getUserId(), id);
-        } else if (type.equals("lost-adoptions")) {
-            bookmarked = toggleBookmarkUseCase.toggleLostAdoptionBookmark(principal.getUserId(), id);
-        } else {
-            throw new BaseException(LOST_ANIMAL_TYPE_MISSING_ERROR);
-        }
+        boolean bookmarked = toggleBookmarkUseCase.toggleLostPostBookmark(principal.getUserId(), id);
+        return ResponseEntity.ok(new BookmarkResponse(bookmarked));
+    }
+
+    @PostMapping("/lost-animals/lost-adoptions/{id}/toggle")
+    public ResponseEntity<BookmarkResponse> toggleLostAdoptionBookmark(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long id
+    ) {
+        // 북마크 토글 후 북마크 상태 받아오기
+        boolean bookmarked = toggleBookmarkUseCase.toggleLostAdoptionBookmark(principal.getUserId(), id);
         return ResponseEntity.ok(new BookmarkResponse(bookmarked));
     }
 

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
@@ -1,0 +1,28 @@
+package kr.co.pawong.pwbe.user.adapter.in.api;
+
+import kr.co.pawong.pwbe.user.adapter.in.api.dto.response.BookmarkResponse;
+import kr.co.pawong.pwbe.user.adapter.out.security.CustomUserDetails;
+import kr.co.pawong.pwbe.user.application.port.in.ToggleBookmarkUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/api/users/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final ToggleBookmarkUseCase toggleBookmarkUseCase;
+
+    @PostMapping("/lost-posts/{lostPostId}/toggle")
+    public ResponseEntity<BookmarkResponse> toggleLostPostBookmark(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable Long lostPostId
+    ) {
+        // 북마크 토글 후 북마크 상태 받아오기
+        boolean bookmarked = toggleBookmarkUseCase.toggleLostPostBookmark(principal.getUserId(), lostPostId);
+        return ResponseEntity.ok(new BookmarkResponse(bookmarked));
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
@@ -1,5 +1,8 @@
 package kr.co.pawong.pwbe.user.adapter.in.api;
 
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.LOST_ANIMAL_TYPE_MISSING_ERROR;
+
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.user.adapter.in.api.dto.response.BookmarkResponse;
 import kr.co.pawong.pwbe.user.adapter.out.security.CustomUserDetails;
 import kr.co.pawong.pwbe.user.application.port.in.ToggleBookmarkUseCase;
@@ -8,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("/api/users/bookmarks")
@@ -16,23 +20,22 @@ public class BookmarkController {
 
     private final ToggleBookmarkUseCase toggleBookmarkUseCase;
 
-    @PostMapping("/lost-posts/{lostPostId}/toggle")
+    @PostMapping("/lost-animals/{id}/toggle")
     public ResponseEntity<BookmarkResponse> toggleLostPostBookmark(
+            @RequestParam(required = false) String type,
             @AuthenticationPrincipal CustomUserDetails principal,
-            @PathVariable Long lostPostId
+            @PathVariable Long id
     ) {
+        boolean bookmarked;
         // 북마크 토글 후 북마크 상태 받아오기
-        boolean bookmarked = toggleBookmarkUseCase.toggleLostPostBookmark(principal.getUserId(), lostPostId);
+        if (type.equals("lost-posts")) {
+            bookmarked = toggleBookmarkUseCase.toggleLostPostBookmark(principal.getUserId(), id);
+        } else if (type.equals("lost-adoptions")) {
+            bookmarked = toggleBookmarkUseCase.toggleLostAdoptionBookmark(principal.getUserId(), id);
+        } else {
+            throw new BaseException(LOST_ANIMAL_TYPE_MISSING_ERROR);
+        }
         return ResponseEntity.ok(new BookmarkResponse(bookmarked));
     }
 
-    @PostMapping("/adoptions/{adoptionId}/toggle")
-    public ResponseEntity<BookmarkResponse> toggleAdoptionPostBookmark(
-            @AuthenticationPrincipal CustomUserDetails principal,
-            @PathVariable Long adoptionId
-    ) {
-        // 북마크 토글 후 북마크 상태 받아오기
-        boolean bookmarked = toggleBookmarkUseCase.toggleLostAdoptionBookmark(principal.getUserId(), adoptionId);
-        return ResponseEntity.ok(new BookmarkResponse(bookmarked));
-    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/BookmarkController.java
@@ -1,6 +1,5 @@
 package kr.co.pawong.pwbe.user.adapter.in.api;
 
-import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.user.adapter.in.api.dto.response.BookmarkResponse;
 import kr.co.pawong.pwbe.user.adapter.out.security.CustomUserDetails;
 import kr.co.pawong.pwbe.user.application.port.in.ToggleBookmarkUseCase;
@@ -9,10 +8,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/api/users/bookmarks")
+@RestController
+@RequestMapping("/api/users/bookmarks")
 @RequiredArgsConstructor
 public class BookmarkController {
 

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/LostBookmarkController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/LostBookmarkController.java
@@ -12,13 +12,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/users/bookmarks")
+@RequestMapping("/api/users/bookmarks/lost-animals")
 @RequiredArgsConstructor
-public class BookmarkController {
+public class LostBookmarkController {
 
     private final ToggleBookmarkUseCase toggleBookmarkUseCase;
 
-    @PostMapping("/lost-animals/lost-posts/{id}/toggle")
+    @PostMapping("/lost-posts/{id}/toggle")
     public ResponseEntity<BookmarkResponse> toggleLostPostsBookmark(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long id
@@ -28,7 +28,7 @@ public class BookmarkController {
         return ResponseEntity.ok(new BookmarkResponse(bookmarked));
     }
 
-    @PostMapping("/lost-animals/lost-adoptions/{id}/toggle")
+    @PostMapping("/lost-adoptions/{id}/toggle")
     public ResponseEntity<BookmarkResponse> toggleLostAdoptionBookmark(
             @AuthenticationPrincipal CustomUserDetails principal,
             @PathVariable Long id

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/MyPageController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/MyPageController.java
@@ -1,6 +1,8 @@
 package kr.co.pawong.pwbe.user.adapter.in.api;
 
 import java.util.List;
+import kr.co.pawong.pwbe.favorites.application.service.FavoritesService;
+import kr.co.pawong.pwbe.favorites.presentation.dto.response.FavoritesListResponse;
 import kr.co.pawong.pwbe.user.adapter.in.api.dto.response.BaseMyPageResponse;
 import kr.co.pawong.pwbe.user.adapter.out.security.CustomUserDetails;
 import kr.co.pawong.pwbe.user.application.port.in.dto.MyPageLostPostResponse;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyPageController {
 
     private final QueryMyPageDataUseCase queryMyPageDataUseCase;
+    private final FavoritesService favoritesService;
 
     @GetMapping("/lost-posts")
     public ResponseEntity<BaseMyPageResponse<MyPageLostPostResponse>> myPageLostPosts(
@@ -35,5 +38,18 @@ public class MyPageController {
         List<MyPageLostPostResponse> content = queryMyPageDataUseCase.getBookmarkedLostPostsByUserId(
                 principal.getUserId());
         return ResponseEntity.ok(new BaseMyPageResponse<>(content));
+    }
+
+    /**
+     * 현재 로그인된 유저가 찜 목록을 받아오는 API
+     * TODO BaseMyPageResponse로 반환 스펙 맞추기
+     */
+    @GetMapping("/favorites")
+    public ResponseEntity<FavoritesListResponse> getFavorites(
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        Long userId = principal.getUserId();
+        FavoritesListResponse response = favoritesService.findAllByUserId(userId);   // favorites가 도메인명이므로 favoritesList로 네이밍
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/MyPageController.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/MyPageController.java
@@ -25,7 +25,15 @@ public class MyPageController {
     ) {
         List<MyPageLostPostResponse> content = queryMyPageDataUseCase.getLostPostsByUserId(
                 principal.getUserId());
-        return ResponseEntity.ok(
-                new BaseMyPageResponse<>(content));
+        return ResponseEntity.ok(new BaseMyPageResponse<>(content));
+    }
+
+    @GetMapping("/lost-bookmarks")
+    public ResponseEntity<BaseMyPageResponse<MyPageLostPostResponse>> myPageLostBookmarks(
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        List<MyPageLostPostResponse> content = queryMyPageDataUseCase.getBookmarkedLostPostsByUserId(
+                principal.getUserId());
+        return ResponseEntity.ok(new BaseMyPageResponse<>(content));
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/dto/response/BookmarkResponse.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/in/api/dto/response/BookmarkResponse.java
@@ -1,0 +1,7 @@
+package kr.co.pawong.pwbe.user.adapter.in.api.dto.response;
+
+public record BookmarkResponse(
+        boolean bookmarked
+) {
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkCommandAdapter.java
@@ -1,0 +1,27 @@
+package kr.co.pawong.pwbe.user.adapter.out.jpa;
+
+import kr.co.pawong.pwbe.user.adapter.out.jpa.entity.LostBookmarkEntity;
+import kr.co.pawong.pwbe.user.adapter.out.jpa.repository.LostBookmarkRepository;
+import kr.co.pawong.pwbe.user.application.port.out.LostBookmarkCommandPort;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaLostBookmarkCommandAdapter implements LostBookmarkCommandPort {
+
+    private final LostBookmarkRepository lostBookmarkRepository;
+
+    @Override
+    public LostBookmark save(LostBookmark bookmark) {
+        // 북마크는 업데이트 하는 경우가 없어서 save_로만 저장합니다.
+        return lostBookmarkRepository.save(LostBookmarkEntity.of(bookmark))
+                .toDomain();
+    }
+
+    @Override
+    public void delete(Long bookmarkId) {
+        lostBookmarkRepository.deleteById(bookmarkId);
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
@@ -43,10 +43,10 @@ public class JpaLostBookmarkQueryAdapter implements LostBookmarkQueryPort {
     }
 
     @Override
-    public boolean lostAdoptionBookmarkExists(Long userId, long bookmarkId) {
+    public boolean lostAdoptionBookmarkExists(Long userId, long adoptionId) {
         if (userId == null) {
             return false;
         }
-        return lostBookmarkRepository.existsByUserIdAndLostPostId(userId, bookmarkId);
+        return lostBookmarkRepository.existsByUserIdAndAdoptionId(userId, adoptionId);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
@@ -33,4 +33,20 @@ public class JpaLostBookmarkQueryAdapter implements LostBookmarkQueryPort {
                 .map(LostBookmarkEntity::toDomain)
                 .toList();
     }
+
+    @Override
+    public boolean lostPostBookmarkExists(Long userId, long lostPostId) {
+        if (userId == null) {
+            return false;
+        }
+        return lostBookmarkRepository.existsByUserIdAndLostPostId(userId, lostPostId);
+    }
+
+    @Override
+    public boolean lostAdoptionBookmarkExists(Long userId, long bookmarkId) {
+        if (userId == null) {
+            return false;
+        }
+        return lostBookmarkRepository.existsByUserIdAndLostPostId(userId, bookmarkId);
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
@@ -1,5 +1,6 @@
 package kr.co.pawong.pwbe.user.adapter.out.jpa;
 
+import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.user.adapter.out.jpa.entity.LostBookmarkEntity;
 import kr.co.pawong.pwbe.user.adapter.out.jpa.repository.LostBookmarkRepository;
@@ -24,5 +25,12 @@ public class JpaLostBookmarkQueryAdapter implements LostBookmarkQueryPort {
     public Optional<LostBookmark> findByAdoptionId(long userId, long adoptionId) {
         return lostBookmarkRepository.findLostBookmarkEntityByUserIdAndAdoptionId(userId, adoptionId)
                 .map(LostBookmarkEntity::toDomain);
+    }
+
+    @Override
+    public List<LostBookmark> findByUserId(long userId) {
+        return lostBookmarkRepository.findByUserId(userId).stream()
+                .map(LostBookmarkEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/JpaLostBookmarkQueryAdapter.java
@@ -10,18 +10,18 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class LostBookmarkQueryAdapter implements LostBookmarkQueryPort {
+public class JpaLostBookmarkQueryAdapter implements LostBookmarkQueryPort {
 
     private final LostBookmarkRepository lostBookmarkRepository;
 
     @Override
-    public Optional<LostBookmark> findLostBookmarkByLostPostId(long userId, long lostPostId) {
+    public Optional<LostBookmark> findByLostPostId(long userId, long lostPostId) {
         return lostBookmarkRepository.findLostBookmarkEntityByUserIdAndLostPostId(userId, lostPostId)
                 .map(LostBookmarkEntity::toDomain);
     }
 
     @Override
-    public Optional<LostBookmark> findLostBookmarkByAdoptionId(long userId, long adoptionId) {
+    public Optional<LostBookmark> findByAdoptionId(long userId, long adoptionId) {
         return lostBookmarkRepository.findLostBookmarkEntityByUserIdAndAdoptionId(userId, adoptionId)
                 .map(LostBookmarkEntity::toDomain);
     }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/LostBookmarkQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/LostBookmarkQueryAdapter.java
@@ -1,0 +1,28 @@
+package kr.co.pawong.pwbe.user.adapter.out.jpa;
+
+import java.util.Optional;
+import kr.co.pawong.pwbe.user.adapter.out.jpa.entity.LostBookmarkEntity;
+import kr.co.pawong.pwbe.user.adapter.out.jpa.repository.LostBookmarkRepository;
+import kr.co.pawong.pwbe.user.application.port.out.LostBookmarkQueryPort;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LostBookmarkQueryAdapter implements LostBookmarkQueryPort {
+
+    private final LostBookmarkRepository lostBookmarkRepository;
+
+    @Override
+    public Optional<LostBookmark> findLostBookmarkByLostPostId(long userId, long lostPostId) {
+        return lostBookmarkRepository.findLostBookmarkEntityByUserIdAndLostPostId(userId, lostPostId)
+                .map(LostBookmarkEntity::toDomain);
+    }
+
+    @Override
+    public Optional<LostBookmark> findLostBookmarkByAdoptionId(long userId, long adoptionId) {
+        return lostBookmarkRepository.findLostBookmarkEntityByUserIdAndAdoptionId(userId, adoptionId)
+                .map(LostBookmarkEntity::toDomain);
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/entity/LostBookmarkEntity.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/entity/LostBookmarkEntity.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "LostBookmarks")
+// TODO: 제약조건 추가해야 됨 (외래키 제약조건 + lostPostId와 adoptionId 제약 조건)
+// TODO: 그리고 없는 userId나 lostPostId, adoptionId에 대해 데이터 insert시에 발생하는 에러 예외처리 해야 됨
 public class LostBookmarkEntity {
 
     @Id
@@ -32,6 +34,7 @@ public class LostBookmarkEntity {
     private Long adoptionId;
 
     public static LostBookmarkEntity of(LostBookmark lostBookmark) {
+
         return LostBookmarkEntity.builder()
                 .bookmarkId(lostBookmark.getBookmarkId())
                 .userId(lostBookmark.getUserId())

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/entity/LostBookmarkEntity.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/entity/LostBookmarkEntity.java
@@ -1,0 +1,51 @@
+package kr.co.pawong.pwbe.user.adapter.out.jpa.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "LostBookmarks")
+public class LostBookmarkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bookmarkId;
+
+    private Long userId;
+
+    private Long lostPostId;
+    private Long adoptionId;
+
+    public static LostBookmarkEntity of(LostBookmark lostBookmark) {
+        return LostBookmarkEntity.builder()
+                .bookmarkId(lostBookmark.getBookmarkId())
+                .userId(lostBookmark.getUserId())
+                .lostPostId(lostBookmark.getLostPostId())
+                .adoptionId(lostBookmark.getAdoptionId())
+                .build();
+    }
+
+    public LostBookmark toDomain() {
+        return LostBookmark.builder()
+                .bookmarkId(this.bookmarkId)
+                .userId(this.userId)
+                .lostPostId(this.lostPostId)
+                .adoptionId(this.adoptionId)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/repository/LostBookmarkRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/repository/LostBookmarkRepository.java
@@ -1,0 +1,12 @@
+package kr.co.pawong.pwbe.user.adapter.out.jpa.repository;
+
+import java.util.Optional;
+import kr.co.pawong.pwbe.user.adapter.out.jpa.entity.LostBookmarkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LostBookmarkRepository extends JpaRepository<LostBookmarkEntity, Long> {
+
+    Optional<LostBookmarkEntity> findLostBookmarkEntityByUserIdAndLostPostId(Long userId, Long lostPostId);
+
+    Optional<LostBookmarkEntity> findLostBookmarkEntityByUserIdAndAdoptionId(Long userId, Long adoptionId);
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/repository/LostBookmarkRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/repository/LostBookmarkRepository.java
@@ -13,4 +13,8 @@ public interface LostBookmarkRepository extends JpaRepository<LostBookmarkEntity
     Optional<LostBookmarkEntity> findLostBookmarkEntityByUserIdAndAdoptionId(Long userId, Long adoptionId);
 
     List<LostBookmarkEntity> findByUserId(Long userId);
+
+    boolean existsByUserIdAndLostPostId(Long userId, Long lostPostId);
+
+    boolean existsByUserIdAndAdoptionId(Long userId, Long adoptionId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/repository/LostBookmarkRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/jpa/repository/LostBookmarkRepository.java
@@ -1,5 +1,7 @@
 package kr.co.pawong.pwbe.user.adapter.out.jpa.repository;
 
+import io.micrometer.core.instrument.Tags;
+import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.user.adapter.out.jpa.entity.LostBookmarkEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,6 @@ public interface LostBookmarkRepository extends JpaRepository<LostBookmarkEntity
     Optional<LostBookmarkEntity> findLostBookmarkEntityByUserIdAndLostPostId(Long userId, Long lostPostId);
 
     Optional<LostBookmarkEntity> findLostBookmarkEntityByUserIdAndAdoptionId(Long userId, Long adoptionId);
+
+    List<LostBookmarkEntity> findByUserId(Long userId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
@@ -2,12 +2,16 @@ package kr.co.pawong.pwbe.user.adapter.out.lostPost;
 
 import java.util.List;
 import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostPostDataUseCase;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
+import kr.co.pawong.pwbe.user.adapter.out.lostPost.mapper.LostAnimalQueryMapper;
 import kr.co.pawong.pwbe.user.application.port.out.LostPostInfoPort;
 import kr.co.pawong.pwbe.user.application.port.out.dto.MyPageLostPostInfo;
 import kr.co.pawong.pwbe.user.application.port.out.mapper.LostPostMapper;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -16,6 +20,7 @@ public class LostPostInfoAdapter implements LostPostInfoPort {
     private final QueryLostPostDataUseCase queryLostPostDataUseCase;
 
     @Override
+    @Transactional(readOnly = true)
     public List<MyPageLostPostInfo> getLostPostsByUserId(Long userId) {
         List<LostPostCard> lostPostCards = queryLostPostDataUseCase.getLostPostsByUserId(userId);
 
@@ -23,4 +28,21 @@ public class LostPostInfoAdapter implements LostPostInfoPort {
                 .map(LostPostMapper::toMyPostLostPostInfo)
                 .toList();
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyPageLostPostInfo> getLostAnimalsByLostPostIds(List<LostBookmark> lostPostIds) {
+        // dto 변환
+        List<LostAnimalQuery> queryDtoList = lostPostIds.stream()
+                .map(LostAnimalQueryMapper::toLostAnimalQuery)
+                .toList();
+        // LostPost 도메인으로 요청
+        List<LostPostCard> lostPostCards = queryLostPostDataUseCase.getLostAnimalsByPostIds(
+                queryDtoList);
+        return lostPostCards.stream()
+                .map(LostPostMapper::toMyPostLostPostInfo)
+                .toList();
+
+    }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.user.adapter.out.lostPost;
 
 import java.util.List;
+import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostAnimalDataUseCase;
 import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostPostDataUseCase;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LostPostInfoAdapter implements LostPostInfoPort {
 
     private final QueryLostPostDataUseCase queryLostPostDataUseCase;
+    private final QueryLostAnimalDataUseCase queryLostAnimalDataUseCase;
 
     @Override
     @Transactional(readOnly = true)
@@ -37,7 +39,7 @@ public class LostPostInfoAdapter implements LostPostInfoPort {
                 .map(LostAnimalQueryMapper::toLostAnimalQuery)
                 .toList();
         // LostPost 도메인으로 요청
-        List<LostPostCard> lostPostCards = queryLostPostDataUseCase.getLostAnimalsByIds(
+        List<LostPostCard> lostPostCards = queryLostAnimalDataUseCase.getLostAnimalsByIds(
                 queryDtoList);
         return lostPostCards.stream()
                 .map(LostPostMapper::toMyPostLostPostInfo)

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
@@ -31,9 +31,9 @@ public class LostPostInfoAdapter implements LostPostInfoPort {
 
     @Override
     @Transactional(readOnly = true)
-    public List<MyPageLostPostInfo> getLostAnimalsByLostPostIds(List<LostBookmark> lostPostIds) {
+    public List<MyPageLostPostInfo> getLostAnimalsByIds(List<LostBookmark> lostIds) {
         // dto 변환
-        List<LostAnimalQuery> queryDtoList = lostPostIds.stream()
+        List<LostAnimalQuery> queryDtoList = lostIds.stream()
                 .map(LostAnimalQueryMapper::toLostAnimalQuery)
                 .toList();
         // LostPost 도메인으로 요청

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/LostPostInfoAdapter.java
@@ -37,7 +37,7 @@ public class LostPostInfoAdapter implements LostPostInfoPort {
                 .map(LostAnimalQueryMapper::toLostAnimalQuery)
                 .toList();
         // LostPost 도메인으로 요청
-        List<LostPostCard> lostPostCards = queryLostPostDataUseCase.getLostAnimalsByPostIds(
+        List<LostPostCard> lostPostCards = queryLostPostDataUseCase.getLostAnimalsByIds(
                 queryDtoList);
         return lostPostCards.stream()
                 .map(LostPostMapper::toMyPostLostPostInfo)

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/mapper/LostAnimalQueryMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/mapper/LostAnimalQueryMapper.java
@@ -1,0 +1,25 @@
+package kr.co.pawong.pwbe.user.adapter.out.lostPost.mapper;
+
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
+import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery.LostType;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+
+public class LostAnimalQueryMapper {
+
+    public static LostAnimalQuery toLostAnimalQuery(LostBookmark lostBookmark) {
+
+        // LostPostId_가 있으면 LostPost_에 대한 즐겨찾기
+        if (lostBookmark.getLostPostId() != null) {
+            return LostAnimalQuery.builder()
+                    .type(LostType.LOST_POST)
+                    .id(lostBookmark.getLostPostId())
+                    .build();
+        } else {
+            return LostAnimalQuery.builder()
+                    .type(LostType.LOST_ADOPTION)
+                    .id(lostBookmark.getAdoptionId())
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/mapper/LostAnimalQueryMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/lostPost/mapper/LostAnimalQueryMapper.java
@@ -13,11 +13,13 @@ public class LostAnimalQueryMapper {
             return LostAnimalQuery.builder()
                     .type(LostType.LOST_POST)
                     .id(lostBookmark.getLostPostId())
+                    .userId(lostBookmark.getUserId())
                     .build();
         } else {
             return LostAnimalQuery.builder()
                     .type(LostType.LOST_ADOPTION)
                     .id(lostBookmark.getAdoptionId())
+                    .userId(lostBookmark.getUserId())
                     .build();
         }
     }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/QueryBookmarkDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/QueryBookmarkDataUseCase.java
@@ -1,0 +1,10 @@
+package kr.co.pawong.pwbe.user.application.port.in;
+
+import java.util.List;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+
+public interface QueryBookmarkDataUseCase {
+
+    List<LostBookmark> getBookmarksByUserId(long userId);
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/QueryBookmarkDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/QueryBookmarkDataUseCase.java
@@ -7,4 +7,8 @@ public interface QueryBookmarkDataUseCase {
 
     List<LostBookmark> getBookmarksByUserId(long userId);
 
+    boolean lostPostBookmarkExists(Long userId, long lostPostId);
+
+    boolean lostAdoptionBookmarkExists(Long userId, long bookmarkId);
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/QueryMyPageDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/QueryMyPageDataUseCase.java
@@ -7,4 +7,6 @@ public interface QueryMyPageDataUseCase {
 
     List<MyPageLostPostResponse> getLostPostsByUserId(Long userId);
 
+    List<MyPageLostPostResponse> getBookmarkedLostPostsByUserId(Long userId);
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/ToggleBookmarkUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/ToggleBookmarkUseCase.java
@@ -1,0 +1,9 @@
+package kr.co.pawong.pwbe.user.application.port.in;
+
+public interface ToggleBookmarkUseCase {
+
+    /**
+     * LostPost 북마크 토글
+     */
+    boolean toggleLostPostBookmark(Long userId, Long lostPostId);
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/ToggleBookmarkUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/ToggleBookmarkUseCase.java
@@ -5,5 +5,10 @@ public interface ToggleBookmarkUseCase {
     /**
      * LostPost 북마크 토글
      */
-    boolean toggleLostPostBookmark(Long userId, Long lostPostId);
+    boolean toggleLostPostBookmark(long userId, long lostPostId);
+
+    /**
+     * Adoption Lost 북마크 토글
+     */
+    boolean toggleLostAdoptionBookmark(long userId, long adoptionId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/dto/MyPageLostPostResponse.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/dto/MyPageLostPostResponse.java
@@ -15,7 +15,8 @@ public record MyPageLostPostResponse(
         String happenedPlace,
         String kindNm,
         String createdAt,
-        String feature
+        String feature,
+        boolean bookmarked
 ) {
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/dto/MyPageLostPostResponse.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/dto/MyPageLostPostResponse.java
@@ -13,7 +13,6 @@ public record MyPageLostPostResponse(
         String imageUrl,
         String happenedDate,
         String happenedPlace,
-        String upKindNm,
         String kindNm,
         String createdAt,
         String feature

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapper.java
@@ -23,6 +23,7 @@ public class MyPageMapper {
                 .kindNm(myPageLostPostInfo.kindNm())
                 .createdAt(myPageLostPostInfo.createdAt())
                 .feature(myPageLostPostInfo.feature())
+                .bookmarked(myPageLostPostInfo.bookmarked())
                 .build();
     }
 

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapper.java
@@ -20,7 +20,6 @@ public class MyPageMapper {
                 .imageUrl(myPageLostPostInfo.imageUrl())
                 .happenedDate(myPageLostPostInfo.happenedDate())
                 .happenedPlace(myPageLostPostInfo.happenedPlace())
-                .upKindNm(myPageLostPostInfo.upKindNm())
                 .kindNm(myPageLostPostInfo.kindNm())
                 .createdAt(myPageLostPostInfo.createdAt())
                 .feature(myPageLostPostInfo.feature())

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkCommandPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkCommandPort.java
@@ -1,0 +1,10 @@
+package kr.co.pawong.pwbe.user.application.port.out;
+
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+
+public interface LostBookmarkCommandPort {
+
+    LostBookmark save(LostBookmark bookmark);
+
+    void delete(Long bookmarkId);
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
@@ -1,0 +1,11 @@
+package kr.co.pawong.pwbe.user.application.port.out;
+
+import java.util.Optional;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+
+public interface LostBookmarkQueryPort {
+
+    Optional<LostBookmark> findLostBookmarkByLostPostId(long userId, long lostPostId);
+
+    Optional<LostBookmark> findLostBookmarkByAdoptionId(long userId, long adoptionId);
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
@@ -1,5 +1,6 @@
 package kr.co.pawong.pwbe.user.application.port.out;
 
+import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.user.domain.LostBookmark;
 
@@ -8,4 +9,6 @@ public interface LostBookmarkQueryPort {
     Optional<LostBookmark> findByLostPostId(long userId, long lostPostId);
 
     Optional<LostBookmark> findByAdoptionId(long userId, long adoptionId);
+
+    List<LostBookmark> findByUserId(long userId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
@@ -11,4 +11,8 @@ public interface LostBookmarkQueryPort {
     Optional<LostBookmark> findByAdoptionId(long userId, long adoptionId);
 
     List<LostBookmark> findByUserId(long userId);
+
+    boolean lostPostBookmarkExists(Long userId, long lostPostId);
+
+    boolean lostAdoptionBookmarkExists(Long userId, long bookmarkId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostBookmarkQueryPort.java
@@ -5,7 +5,7 @@ import kr.co.pawong.pwbe.user.domain.LostBookmark;
 
 public interface LostBookmarkQueryPort {
 
-    Optional<LostBookmark> findLostBookmarkByLostPostId(long userId, long lostPostId);
+    Optional<LostBookmark> findByLostPostId(long userId, long lostPostId);
 
-    Optional<LostBookmark> findLostBookmarkByAdoptionId(long userId, long adoptionId);
+    Optional<LostBookmark> findByAdoptionId(long userId, long adoptionId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostPostInfoPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostPostInfoPort.java
@@ -8,5 +8,5 @@ public interface LostPostInfoPort {
 
     List<MyPageLostPostInfo> getLostPostsByUserId(Long userId);
 
-    List<MyPageLostPostInfo> getLostAnimalsByLostPostIds(List<LostBookmark> lostPostIds);
+    List<MyPageLostPostInfo> getLostAnimalsByIds(List<LostBookmark> lostIds);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostPostInfoPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/LostPostInfoPort.java
@@ -2,8 +2,11 @@ package kr.co.pawong.pwbe.user.application.port.out;
 
 import java.util.List;
 import kr.co.pawong.pwbe.user.application.port.out.dto.MyPageLostPostInfo;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
 
 public interface LostPostInfoPort {
 
     List<MyPageLostPostInfo> getLostPostsByUserId(Long userId);
+
+    List<MyPageLostPostInfo> getLostAnimalsByLostPostIds(List<LostBookmark> lostPostIds);
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/dto/MyPageLostPostInfo.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/dto/MyPageLostPostInfo.java
@@ -13,7 +13,6 @@ public record MyPageLostPostInfo(
         String imageUrl,
         String happenedDate,
         String happenedPlace,
-        String upKindNm,
         String kindNm,
         String createdAt,
         String feature

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/dto/MyPageLostPostInfo.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/dto/MyPageLostPostInfo.java
@@ -15,7 +15,8 @@ public record MyPageLostPostInfo(
         String happenedPlace,
         String kindNm,
         String createdAt,
-        String feature
+        String feature,
+        boolean bookmarked
 ) {
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/port/out/mapper/LostPostMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/port/out/mapper/LostPostMapper.java
@@ -20,6 +20,7 @@ public class LostPostMapper {
                 .kindNm(lostPostCard.kindNm())
                 .createdAt(lostPostCard.createdAt())
                 .feature(lostPostCard.feature())
+                .bookmarked(lostPostCard.bookmarked())
                 .build();
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryBookmarkDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryBookmarkDataService.java
@@ -26,7 +26,7 @@ public class QueryBookmarkDataService implements QueryBookmarkDataUseCase {
     }
 
     @Override
-    public boolean lostAdoptionBookmarkExists(Long userId, long bookmarkId) {
-        return lostBookmarkQueryPort.lostAdoptionBookmarkExists(userId, bookmarkId);
+    public boolean lostAdoptionBookmarkExists(Long userId, long adoptionId) {
+        return lostBookmarkQueryPort.lostAdoptionBookmarkExists(userId, adoptionId);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryBookmarkDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryBookmarkDataService.java
@@ -1,0 +1,22 @@
+package kr.co.pawong.pwbe.user.application.service;
+
+import java.util.List;
+import kr.co.pawong.pwbe.user.application.port.in.QueryBookmarkDataUseCase;
+import kr.co.pawong.pwbe.user.application.port.out.LostBookmarkQueryPort;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QueryBookmarkDataService implements QueryBookmarkDataUseCase {
+
+    private final LostBookmarkQueryPort lostBookmarkQueryPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LostBookmark> getBookmarksByUserId(long userId) {
+        return lostBookmarkQueryPort.findByUserId(userId);
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryBookmarkDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryBookmarkDataService.java
@@ -19,4 +19,14 @@ public class QueryBookmarkDataService implements QueryBookmarkDataUseCase {
     public List<LostBookmark> getBookmarksByUserId(long userId) {
         return lostBookmarkQueryPort.findByUserId(userId);
     }
+
+    @Override
+    public boolean lostPostBookmarkExists(Long userId, long lostPostId) {
+        return lostBookmarkQueryPort.lostPostBookmarkExists(userId, lostPostId);
+    }
+
+    @Override
+    public boolean lostAdoptionBookmarkExists(Long userId, long bookmarkId) {
+        return lostBookmarkQueryPort.lostAdoptionBookmarkExists(userId, bookmarkId);
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataService.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.user.application.service;
 
 import java.util.List;
+import kr.co.pawong.pwbe.user.application.port.in.QueryBookmarkDataUseCase;
 import kr.co.pawong.pwbe.user.application.port.in.QueryMyPageDataUseCase;
 import kr.co.pawong.pwbe.user.application.port.in.dto.MyPageLostPostResponse;
 import kr.co.pawong.pwbe.user.application.port.out.LostPostInfoPort;
@@ -8,6 +9,7 @@ import kr.co.pawong.pwbe.user.application.port.in.mapper.MyPageMapper;
 import kr.co.pawong.pwbe.user.application.port.out.dto.MyPageLostPostInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +17,10 @@ public class QueryMyPageDataService implements QueryMyPageDataUseCase {
 
     private final LostPostInfoPort lostPostInfoPort;
 
+    private final QueryBookmarkDataUseCase queryBookmarkDataUseCase;
+
     @Override
+    @Transactional(readOnly = true)
     public List<MyPageLostPostResponse> getLostPostsByUserId(Long userId) {
         List<MyPageLostPostInfo> myPageLostPosts = lostPostInfoPort.getLostPostsByUserId(userId);
 
@@ -23,4 +28,17 @@ public class QueryMyPageDataService implements QueryMyPageDataUseCase {
                 .map(MyPageMapper::toMyPageLostPostResponse)
                 .toList();
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyPageLostPostResponse> getBookmarkedLostPostsByUserId(Long userId) {
+        List<MyPageLostPostInfo> myPageLostPosts = lostPostInfoPort.getLostAnimalsByLostPostIds(
+                queryBookmarkDataUseCase.getBookmarksByUserId(userId)
+        );
+
+        return myPageLostPosts.stream()
+                .map(MyPageMapper::toMyPageLostPostResponse)
+                .toList();
+    }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataService.java
@@ -32,7 +32,7 @@ public class QueryMyPageDataService implements QueryMyPageDataUseCase {
     @Override
     @Transactional(readOnly = true)
     public List<MyPageLostPostResponse> getBookmarkedLostPostsByUserId(Long userId) {
-        List<MyPageLostPostInfo> myPageLostPosts = lostPostInfoPort.getLostAnimalsByLostPostIds(
+        List<MyPageLostPostInfo> myPageLostPosts = lostPostInfoPort.getLostAnimalsByIds(
                 queryBookmarkDataUseCase.getBookmarksByUserId(userId)
         );
 

--- a/src/main/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkService.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkService.java
@@ -1,15 +1,56 @@
 package kr.co.pawong.pwbe.user.application.service;
 
 import kr.co.pawong.pwbe.user.application.port.in.ToggleBookmarkUseCase;
+import kr.co.pawong.pwbe.user.application.port.out.LostBookmarkCommandPort;
+import kr.co.pawong.pwbe.user.application.port.out.LostBookmarkQueryPort;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ToggleBookmarkService implements ToggleBookmarkUseCase {
 
+    private final LostBookmarkQueryPort bookmarkQueryPort;
+    private final LostBookmarkCommandPort bookmarkCommandPort;
+
+    // 실종 게시물에 대한 Bookmark
     @Override
-    public boolean toggleLostPostBookmark(Long userId, Long lostPostId) {
-        return false;
+    @Transactional
+    public boolean toggleLostPostBookmark(long userId, long lostPostId) {
+
+        return bookmarkQueryPort.findByLostPostId(userId, lostPostId)
+                .map(bookmark -> {
+                    // 있으면 북마크 삭제
+                    bookmarkCommandPort.delete(bookmark.getBookmarkId());
+                    return false;
+                })
+                .orElseGet(() -> {
+                    // 없으면 북마크 생성
+                    bookmarkCommandPort.save(
+                            LostBookmark.createByLostPostId(userId, lostPostId)
+                    );
+                    return true;
+                });
+    }
+
+    // 실종 API 데이터에 대한 Bookmark
+    @Override
+    @Transactional
+    public boolean toggleLostAdoptionBookmark(long userId, long adoptionId) {
+        return bookmarkQueryPort.findByAdoptionId(userId, adoptionId)
+                .map(bookmark -> {
+                    // 있으면 북마크 삭제
+                    bookmarkCommandPort.delete(bookmark.getBookmarkId());
+                    return false;
+                })
+                .orElseGet(() -> {
+                    // 없으면 북마크 생성
+                    bookmarkCommandPort.save(
+                            LostBookmark.createByAdoptionId(userId, adoptionId)
+                    );
+                    return true;
+                });
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkService.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkService.java
@@ -1,0 +1,15 @@
+package kr.co.pawong.pwbe.user.application.service;
+
+import kr.co.pawong.pwbe.user.application.port.in.ToggleBookmarkUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ToggleBookmarkService implements ToggleBookmarkUseCase {
+
+    @Override
+    public boolean toggleLostPostBookmark(Long userId, Long lostPostId) {
+        return false;
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/user/domain/LostBookmark.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/domain/LostBookmark.java
@@ -1,6 +1,5 @@
 package kr.co.pawong.pwbe.user.domain;
 
-import kr.co.pawong.pwbe.user.adapter.out.jpa.entity.UserEntity;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,4 +11,18 @@ public class LostBookmark {
     private Long userId;
     private Long lostPostId;
     private Long adoptionId;
+
+    public static LostBookmark createByLostPostId(long userId, long lostPostId) {
+        return LostBookmark.builder()
+                .userId(userId)
+                .lostPostId(lostPostId)
+                .build();
+    }
+
+    public static LostBookmark createByAdoptionId(long userId, long adoptionId) {
+        return LostBookmark.builder()
+                .userId(userId)
+                .adoptionId(adoptionId)
+                .build();
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/user/domain/LostBookmark.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/domain/LostBookmark.java
@@ -1,0 +1,15 @@
+package kr.co.pawong.pwbe.user.domain;
+
+import kr.co.pawong.pwbe.user.adapter.out.jpa.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LostBookmark {
+
+    private Long bookmarkId;
+    private Long userId;
+    private Long lostPostId;
+    private Long adoptionId;
+}

--- a/src/test/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapperTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapperTest.java
@@ -44,7 +44,7 @@ class LostPostCardMapperTest {
                 .build();
 
         // when
-        LostPostCard card = LostPostCardMapper.toLostPostCard( lostPost, "Alice", fixedClock);
+        LostPostCard card = LostPostCardMapper.toLostPostCard( lostPost, "Alice", false, fixedClock);
 
         // then
         assertThat(card.postId()).isEqualTo(1L);

--- a/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataServiceTest.java
@@ -9,8 +9,10 @@ import java.time.ZoneId;
 import java.util.List;
 import kr.co.pawong.pwbe.adoption.enums.UpKindNm;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
+import kr.co.pawong.pwbe.lostPost.application.port.out.LostAdoptionDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
+import kr.co.pawong.pwbe.lostPost.application.service.QueryLostPostDataServiceTest.FakeLostPostDataQueryPort.FakeUserInfoPort;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 import kr.co.pawong.pwbe.lostPost.enums.PostType;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,11 +29,14 @@ class QueryLostPostDataServiceTest {
         // Fake 구현체들로 Service를 직접 생성
         LostPostDataQueryPort fakeLostPostPort = new FakeLostPostDataQueryPort();
         UserInfoPort fakeUserInfoPort = new FakeUserInfoPort();
+        // TODO: 이후 추가
+        LostAdoptionDataQueryPort fakeLostAdoptionDataQueryPort = null;
         Clock fixedClock = Clock.fixed(FIXED_LDT.atZone(ZoneId.systemDefault()).toInstant(),
                 ZoneId.systemDefault());
 
         service = new QueryLostPostDataService(
                 fakeLostPostPort,
+                fakeLostAdoptionDataQueryPort,
                 fakeUserInfoPort,
                 fixedClock
         );
@@ -68,6 +73,7 @@ class QueryLostPostDataServiceTest {
 
     /** userId == 123L 일 때만 하나의 LostPost를, 아니면 빈 리스트를 반환 */
     static class FakeLostPostDataQueryPort implements LostPostDataQueryPort {
+
         @Override
         public List<LostPost> getLostPostsByUserId(Long userId) {
             if (userId.equals(123L)) {
@@ -79,13 +85,14 @@ class QueryLostPostDataServiceTest {
                         .upKindNm(UpKindNm.개)
                         .kindNm("푸들")
                         .specialMark("흰 점이 있음")
-                        .createdAt(LocalDateTime.of(2025,5,1,10,0,0))
+                        .createdAt(LocalDateTime.of(2025, 5, 1, 10, 0, 0))
                         .build();
                 return List.of(lp);
             }
             return List.of();
         }
 
+        // TODO: 이후 구현
         @Override
         public LostPost findLostPostByIdOrThrow(Long lostPostId) {
             if (lostPostId.equals(123L)) {
@@ -97,20 +104,22 @@ class QueryLostPostDataServiceTest {
                         .upKindNm(UpKindNm.개)
                         .kindNm("푸들")
                         .specialMark("흰 점이 있음")
-                        .createdAt(LocalDateTime.of(2025,5,1,10,0,0))
+                        .createdAt(LocalDateTime.of(2025, 5, 1, 10, 0, 0))
                         .build();
                 return lp;
             }
             return null;
         }
-    }
 
-    /** userId == 123L 일 때만 고정 닉네임을 반환 */
-    static class FakeUserInfoPort implements UserInfoPort {
-        @Override
-        public String getNicknameByUserId(Long userId) {
-            return userId.equals(123L) ? "fake-nick" : "";
+        /**
+         * userId == 123L 일 때만 고정 닉네임을 반환
+         */
+        static class FakeUserInfoPort implements UserInfoPort {
+
+            @Override
+            public String getNicknameByUserId(Long userId) {
+                return userId.equals(123L) ? "fake-nick" : "";
+            }
         }
     }
-
 }

--- a/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataServiceTest.java
@@ -29,14 +29,14 @@ class QueryLostPostDataServiceTest {
         // Fake 구현체들로 Service를 직접 생성
         LostPostDataQueryPort fakeLostPostPort = new FakeLostPostDataQueryPort();
         UserInfoPort fakeUserInfoPort = new FakeUserInfoPort();
-        // TODO: 이후 추가
-        LostAdoptionDataQueryPort fakeLostAdoptionDataQueryPort = null;
         Clock fixedClock = Clock.fixed(FIXED_LDT.atZone(ZoneId.systemDefault()).toInstant(),
                 ZoneId.systemDefault());
 
         service = new QueryLostPostDataService(
                 fakeLostPostPort,
-                fakeLostAdoptionDataQueryPort,
+                // TODO: 이후 추가
+                null,
+                null,
                 fakeUserInfoPort,
                 fixedClock
         );

--- a/src/test/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapperTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapperTest.java
@@ -21,6 +21,7 @@ class MyPageMapperTest {
                 .kindNm("Shorthair")
                 .createdAt("2025-04-01 08:30:00")
                 .feature("black and white")
+                .bookmarked(true)
                 .build();
 
         // when
@@ -36,5 +37,6 @@ class MyPageMapperTest {
         assertThat(response.kindNm()).isEqualTo("Shorthair");
         assertThat(response.createdAt()).isEqualTo("2025-04-01 08:30:00");
         assertThat(response.feature()).isEqualTo("black and white");
+        assertThat(response.bookmarked()).isTrue();
     }
 }

--- a/src/test/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapperTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/application/port/in/mapper/MyPageMapperTest.java
@@ -18,7 +18,6 @@ class MyPageMapperTest {
                 .imageUrl("https://www.aaa.com")
                 .happenedDate("2025-04-01")
                 .happenedPlace("Busan")
-                .upKindNm("CAT")
                 .kindNm("Shorthair")
                 .createdAt("2025-04-01 08:30:00")
                 .feature("black and white")
@@ -34,7 +33,6 @@ class MyPageMapperTest {
         assertThat(response.imageUrl()).isEqualTo("https://www.aaa.com");
         assertThat(response.happenedDate()).isEqualTo("2025-04-01");
         assertThat(response.happenedPlace()).isEqualTo("Busan");
-        assertThat(response.upKindNm()).isEqualTo("CAT");
         assertThat(response.kindNm()).isEqualTo("Shorthair");
         assertThat(response.createdAt()).isEqualTo("2025-04-01 08:30:00");
         assertThat(response.feature()).isEqualTo("black and white");

--- a/src/test/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataServiceTest.java
@@ -5,9 +5,11 @@ package kr.co.pawong.pwbe.user.application.service;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.List;
+import kr.co.pawong.pwbe.user.application.port.in.QueryBookmarkDataUseCase;
 import kr.co.pawong.pwbe.user.application.port.in.dto.MyPageLostPostResponse;
 import kr.co.pawong.pwbe.user.application.port.out.LostPostInfoPort;
 import kr.co.pawong.pwbe.user.application.port.out.dto.MyPageLostPostInfo;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +20,9 @@ class QueryMyPageDataServiceTest {
     @BeforeEach
     void setUp() {
         LostPostInfoPort fakePort = new FakeLostPostInfoPort();
-        service = new QueryMyPageDataService(fakePort);
+        // TODO: FAKE_로 만들어서 넣어줘야함.
+        QueryBookmarkDataUseCase queryBookmarkDataUseCase = null;
+        service = new QueryMyPageDataService(fakePort, queryBookmarkDataUseCase);
     }
 
     @Test
@@ -65,6 +69,13 @@ class QueryMyPageDataServiceTest {
                     .feature("none")
                     .build();
             return List.of(info);
+        }
+
+        // TODO: 함수 오버라이딩 작성
+        @Override
+        public List<MyPageLostPostInfo> getLostAnimalsByLostPostIds(
+                List<LostBookmark> lostPostIds) {
+            return List.of();
         }
     }
 }

--- a/src/test/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/application/service/QueryMyPageDataServiceTest.java
@@ -73,8 +73,8 @@ class QueryMyPageDataServiceTest {
 
         // TODO: 함수 오버라이딩 작성
         @Override
-        public List<MyPageLostPostInfo> getLostAnimalsByLostPostIds(
-                List<LostBookmark> lostPostIds) {
+        public List<MyPageLostPostInfo> getLostAnimalsByIds(
+                List<LostBookmark> lostIds) {
             return List.of();
         }
     }

--- a/src/test/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkServiceTest.java
@@ -85,6 +85,16 @@ class ToggleBookmarkServiceTest {
         }
 
         @Override
+        public boolean lostPostBookmarkExists(Long userId, long lostPostId) {
+            return false;
+        }
+
+        @Override
+        public boolean lostAdoptionBookmarkExists(Long userId, long bookmarkId) {
+            return false;
+        }
+
+        @Override
         public LostBookmark save(LostBookmark bookmark) {
             LostBookmark newBookmark = LostBookmark.builder()
                     .bookmarkId(seq++)

--- a/src/test/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkServiceTest.java
@@ -1,0 +1,102 @@
+package kr.co.pawong.pwbe.user.application.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import kr.co.pawong.pwbe.user.application.port.out.LostBookmarkCommandPort;
+import kr.co.pawong.pwbe.user.application.port.out.LostBookmarkQueryPort;
+import kr.co.pawong.pwbe.user.domain.LostBookmark;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ToggleBookmarkServiceTest {
+
+    private ToggleBookmarkService service;
+    private FakeBookmarkPort fakePort;
+
+    @BeforeEach
+    void setUp() {
+        fakePort = new FakeBookmarkPort();
+        service = new ToggleBookmarkService(fakePort, fakePort);
+    }
+
+    @Test
+    void LostPostId_로_LostBookmark_토글_테스트() {
+        long userId = 1, lostPostId = 10;
+
+        // 1) 없을 때 → 생성(true 반환)
+        boolean first = service.toggleLostPostBookmark(userId, lostPostId);
+        assertThat(first).isTrue();
+        assertThat(fakePort.count()).isEqualTo(1);
+
+        // 2) 있을 때 → 삭제(false 반환)
+        boolean second = service.toggleLostPostBookmark(userId, lostPostId);
+        assertThat(second).isFalse();
+        assertThat(fakePort.count()).isZero();
+    }
+
+    @Test
+    void AdoptionId_로_LostBookmark_토글_테스트() {
+        long userId = 2, adoptionId = 20;
+
+        // 1) 없을 때 → 생성(true 반환)
+        boolean first = service.toggleLostAdoptionBookmark(userId, adoptionId);
+        assertThat(first).isTrue();
+        assertThat(fakePort.count()).isEqualTo(1);
+
+        // 2) 있을 때 → 삭제(false 반환)
+        boolean second = service.toggleLostAdoptionBookmark(userId, adoptionId);
+        assertThat(second).isFalse();
+        assertThat(fakePort.count()).isZero();
+    }
+
+    /**
+     * 테스트 의존성 주입을 위한 페이크 구현체
+     */
+    static class FakeBookmarkPort implements LostBookmarkQueryPort, LostBookmarkCommandPort {
+
+        private final Map<Long, LostBookmark> store = new HashMap<>();
+        private long seq = 1L;
+
+        @Override
+        public Optional<LostBookmark> findByLostPostId(long userId, long lostPostId) {
+            return store.values().stream()
+                    .filter(b -> b.getUserId() == userId
+                            && Objects.equals(b.getLostPostId(), lostPostId))
+                    .findFirst();
+        }
+
+        @Override
+        public Optional<LostBookmark> findByAdoptionId(long userId, long adoptionId) {
+            return store.values().stream()
+                    .filter(b -> b.getUserId() == userId
+                            && Objects.equals(b.getAdoptionId(), adoptionId))
+                    .findFirst();
+        }
+
+        @Override
+        public LostBookmark save(LostBookmark bookmark) {
+            LostBookmark newBookmark = LostBookmark.builder()
+                    .bookmarkId(seq++)
+                    .userId(bookmark.getUserId())
+                    .adoptionId(bookmark.getAdoptionId())
+                    .lostPostId(bookmark.getLostPostId())
+                    .build();
+
+            store.put(newBookmark.getBookmarkId(), newBookmark);
+            return newBookmark;
+        }
+
+        @Override
+        public void delete(Long bookmarkId) {
+            store.remove(bookmarkId);
+        }
+
+        int count() {
+            return store.size();
+        }
+    }
+}

--- a/src/test/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/application/service/ToggleBookmarkServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.pawong.pwbe.user.application.service;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -75,6 +76,12 @@ class ToggleBookmarkServiceTest {
                     .filter(b -> b.getUserId() == userId
                             && Objects.equals(b.getAdoptionId(), adoptionId))
                     .findFirst();
+        }
+
+        // TODO: 함수 오버라이딩 작성
+        @Override
+        public List<LostBookmark> findByUserId(long userId) {
+            return List.of();
         }
 
         @Override

--- a/src/test/java/kr/co/pawong/pwbe/user/domain/LostBookmarkTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/user/domain/LostBookmarkTest.java
@@ -1,0 +1,43 @@
+package kr.co.pawong.pwbe.user.domain;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LostBookmarkTest {
+
+    @Test
+    void LostPostId_로_LostBookmark_생성_검증() {
+        // given
+        long userId = 2;
+        long lostPostId = 12;
+
+        // when
+        LostBookmark bookmark = LostBookmark.createByLostPostId(userId, lostPostId);
+
+        // then
+        assertThat(bookmark.getUserId()).isEqualTo(userId);
+        assertThat(bookmark.getLostPostId()).isEqualTo(lostPostId);
+        // 제약 조건 검증
+        assertThat(bookmark.getBookmarkId()).isNull();
+        assertThat(bookmark.getAdoptionId()).isNull();
+    }
+
+    @Test
+    void AdoptionId_로_LostBookmark_생성_검증() {
+        // given
+        long userId = 2;
+        long adoptionId = 12;
+
+        // when
+        LostBookmark bookmark = LostBookmark.createByAdoptionId(userId, adoptionId);
+
+        // then
+        assertThat(bookmark.getUserId()).isEqualTo(userId);
+        assertThat(bookmark.getAdoptionId()).isEqualTo(adoptionId);
+        // 제약 조건 검증
+        assertThat(bookmark.getBookmarkId()).isNull();
+        assertThat(bookmark.getLostPostId()).isNull();
+    }
+  
+}


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#15 -> develop

### 변경 사항
- **북마크 토글**
   ```java
  @RestController
  @RequestMapping("/api/users/bookmarks")
  public class BookmarkController {
      ...
      @PostMapping("/lost-animals/lost-posts/{id}/toggle")
      ...
      @PostMapping("/lost-animals/lost-adoptions/{id}/toggle")
      ...
   ```
  사용자가 게시한 실종 게시물에 대한 북마크 API와 공공 실종 동물에 대한 북마크 API를 나눴습니다.
- **북마크 조회**
  ![image](https://github.com/user-attachments/assets/cb07938d-1a0e-44cd-895f-5a26c80cbfd9)
  북마크 테이블은 **사용자 실종 게시물**과 **공공 실종 동물**에 대한 북마크를 한번에 저장합니다.
  `lost_post_id`가 있으면 사용자 실종 게시물.
  `adoption_id`가 있으면 공공 실종 동물.
  이를 `User` 도메인에서 아래의 dto 리스트를 통해 `lostAnimal` 도메인에 한번에 요청을 보냅니다.
  ```java
  public record LostAnimalQuery(
        LostType type,
        long id, // lostPostId 또는 adoptionId
        long userId
  ) {

        public enum LostType {
            LOST_ADOPTION, LOST_POST
        }
  }
  ```
  그리고 `QueryLostPostDataService`의 `switch`문에서 dto의 `type`을 보고 각각의 테이블을 조회합니다.
  ```java
  private LostPostCard convertToLostPostCard(LostAnimalQuery lostAnimalQuery) {
        return switch (lostAnimalQuery.type()) {
            // Lost Post 가져오기
            case LOST_POST -> {
                LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(
                        lostAnimalQuery.id());
                // 작성자 이름 조회
                String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
                yield LostPostCardMapper.toLostPostCard(lostPost, author, clock);
            }
            // Lost Adoption 가져오기
            case LOST_ADOPTION -> {
                LostAdoption lostAdoption = lostAdoptionDataQueryPort.findAdoptionById(
                        lostAnimalQuery.id());
                // 보호소 이름 조회
                String shelter = shelterCareNmPort.getShelterCareNmByCareRegNo(
                        lostAdoption.getCareRegNo());
                yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, clock);
            }
        };
    }

### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
모든 테스트 코드를 따로 작성하지 못했습니다. ㅜㅜ
사용자 게시글에 대해서는 테스트하지 못했지만, 실종 게시글에 대한 북마크 기능과 북마크 조회는 정상 동작합니다.