### PR TITLE
[PW-22] 게시글 수정 및 삭제 API

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
@@ -1,9 +1,11 @@
 package kr.co.pawong.pwbe.global.error.errorcode;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -20,14 +22,20 @@ public enum CustomErrorCode implements ErrorCode {
     /**
      * 401 UNAUTHORIZED
      */
-    TOKEN_INVALIDATE(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
-    USERNAME_NOT_FOUND(HttpStatus.UNAUTHORIZED, "username 정보로 유저를 찾을 수 없습니다."),
+    TOKEN_INVALIDATE(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    USERNAME_NOT_FOUND(UNAUTHORIZED, "username 정보로 유저를 찾을 수 없습니다."),
+
+    /**
+     * 403 FORBIDDEN
+     */
+    FORBIDDEN_POST_MODIFY(FORBIDDEN, "게시글 수정 및 삭제 권한이 없습니다."),
 
     /**
      * 404 NOT_FOUND
      */
     USER_NOT_FOUND(NOT_FOUND, "유저가 존재하지 않습니다."),
     ADOPTION_NOT_FOUND(NOT_FOUND, "유기동물 정보가 없습니다."),
+    LOSTPOST_NOT_FOUND(NOT_FOUND, "실종동물 게시글 정보가 없습니다."),
 
     /**
      * 500 SERVER_ERROR

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/LostPostCommandController.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/LostPostCommandController.java
@@ -33,4 +33,13 @@ public class LostPostCommandController {
                 .status(HttpStatus.CREATED)
                 .body(new LostPostCreateResponse(createdId));
     }
+
+    @DeleteMapping("/lost-posts/{postId}")
+    public ResponseEntity<Long> deleteLostPost(
+            @PathVariable("postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        lostPostUpdateUseCase.deleteLostPost(postId, userDetails.getUserId());
+        return ResponseEntity.ok(postId);
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/LostPostCommandController.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/LostPostCommandController.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.lostPost.adapter.in.api;
 
 import kr.co.pawong.pwbe.lostPost.adapter.in.api.dto.request.LostPostCreateRequest;
+import kr.co.pawong.pwbe.lostPost.adapter.in.api.dto.request.LostPostUpdateRequest;
 import kr.co.pawong.pwbe.lostPost.adapter.in.api.dto.response.LostPostCreateResponse;
 import kr.co.pawong.pwbe.lostPost.application.port.in.CommandLostPostDataUseCase;
 import kr.co.pawong.pwbe.user.adapter.out.security.CustomUserDetails;
@@ -11,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,6 +36,19 @@ public class LostPostCommandController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(new LostPostCreateResponse(createdId));
+    }
+
+    @PutMapping("/lost-posts/{postId}")
+    public ResponseEntity<Long> updateLostPost(
+            @PathVariable("postId") Long postId,
+            @RequestBody LostPostUpdateRequest lostPostUpdate,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                lostPostUpdateUseCase.updateLostPost(
+                        postId,
+                        lostPostUpdate.toDomain(),
+                        userDetails.getUserId()));
     }
 
     @DeleteMapping("/lost-posts/{postId}")

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/LostPostCommandController.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/LostPostCommandController.java
@@ -8,19 +8,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/lost-posts")
+@RequestMapping("/api/lost-animals")
 @RequiredArgsConstructor
 public class LostPostCommandController {
 
     private final CommandLostPostDataUseCase lostPostUpdateUseCase;
 
-    @PostMapping
+    @PostMapping("/lost-posts")
     public ResponseEntity<LostPostCreateResponse> createLostPost(
             @RequestBody LostPostCreateRequest lostPostCreate,
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/dto/request/LostPostCreateRequest.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/dto/request/LostPostCreateRequest.java
@@ -21,10 +21,10 @@ public class LostPostCreateRequest {
     private String color;           // 색상
     private SexCd sexCd;            // 성별
     private Integer age;            // 나이
-    private String imageUrl;        // 이미지 url
+    private String imageKey;        // 이미지 url Object Key
     private String specialMark;     // 동물 특징
     private String content;         // 상세 내용
-    private String rfidCd;            // 마이크로 칩번호
+    private String rfidCd;          // 마이크로 칩번호
     private String location;        // 실종장소, 발견장소
     private Double latitude;        // 위도
     private Double longitude;       // 경도
@@ -39,7 +39,7 @@ public class LostPostCreateRequest {
                 .color(this.color)
                 .sexCd(this.sexCd)
                 .age(this.age)
-                .imageUrl(this.imageUrl)
+                .imageKey(this.imageKey)
                 .specialMark(this.specialMark)
                 .content(this.content)
                 .rfidCd(this.rfidCd)

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/dto/request/LostPostUpdateRequest.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/dto/request/LostPostUpdateRequest.java
@@ -1,5 +1,52 @@
 package kr.co.pawong.pwbe.lostPost.adapter.in.api.dto.request;
 
+import java.time.LocalDate;
+import kr.co.pawong.pwbe.adoption.enums.SexCd;
+import kr.co.pawong.pwbe.adoption.enums.UpKindCd;
+import kr.co.pawong.pwbe.adoption.enums.UpKindNm;
+import kr.co.pawong.pwbe.lostPost.domain.GeoPoint;
+import kr.co.pawong.pwbe.lostPost.domain.LostPost;
+import kr.co.pawong.pwbe.lostPost.enums.PostType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class LostPostUpdateRequest {
 
+    private Long lostPostId;
+    private PostType postType;      // 실종(LOST), 발견(FOUND), 보호(FOSTER)
+    private LocalDate date;         // 실종날짜, 발견날짜
+    private UpKindNm upKindNm;      // 축종명
+    private String kindNm;          // 품종명
+    private String color;           // 색상
+    private SexCd sexCd;            // 성별
+    private Integer age;            // 나이
+    private String imageUrl;        // 이미지 url
+    private String specialMark;     // 동물 특징
+    private String content;         // 상세 내용
+    private String rfidCd;            // 마이크로 칩번호
+    private String location;        // 실종장소, 발견장소
+    private Double latitude;        // 위도
+    private Double longitude;       // 경도
+
+    public LostPost toDomain() {
+        return LostPost.builder()
+                .lostPostId(this.lostPostId)
+                .postType(this.postType)
+                .date(this.date)
+                .upKindNm(this.upKindNm)
+                .upKindCd(UpKindCd.fromValue(this.upKindNm.getValue()))
+                .kindNm(this.kindNm)
+                .color(this.color)
+                .sexCd(this.sexCd)
+                .age(this.age)
+                .imageUrl(this.imageUrl)
+                .specialMark(this.specialMark)
+                .content(this.content)
+                .rfidCd(this.rfidCd)
+                .location(this.location)
+                .geoPoint(GeoPoint.of(this.latitude, this.longitude))
+                .build();
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/dto/request/LostPostUpdateRequest.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/in/api/dto/request/LostPostUpdateRequest.java
@@ -22,10 +22,10 @@ public class LostPostUpdateRequest {
     private String color;           // 색상
     private SexCd sexCd;            // 성별
     private Integer age;            // 나이
-    private String imageUrl;        // 이미지 url
+    private String imageKey;        // 이미지 url Object Key
     private String specialMark;     // 동물 특징
     private String content;         // 상세 내용
-    private String rfidCd;            // 마이크로 칩번호
+    private String rfidCd;          // 마이크로 칩번호
     private String location;        // 실종장소, 발견장소
     private Double latitude;        // 위도
     private Double longitude;       // 경도
@@ -41,7 +41,7 @@ public class LostPostUpdateRequest {
                 .color(this.color)
                 .sexCd(this.sexCd)
                 .age(this.age)
-                .imageUrl(this.imageUrl)
+                .imageKey(this.imageKey)
                 .specialMark(this.specialMark)
                 .content(this.content)
                 .rfidCd(this.rfidCd)

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/JpaLostPostDataCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/JpaLostPostDataCommandAdapter.java
@@ -1,5 +1,8 @@
 package kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa;
 
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.LOSTPOST_NOT_FOUND;
+
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.entity.LostPostEntity;
 import kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.repository.LostPostJpaRepository;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataCommandPort;
@@ -18,5 +21,12 @@ public class JpaLostPostDataCommandAdapter implements LostPostDataCommandPort {
         return lostPostJpaRepository
                 .save(LostPostEntity.from(lostPost))
                 .toDomain();
+    }
+
+    @Override
+    public void updateDeleteStatus(Long postId, Long userId) {
+        lostPostJpaRepository.getByLostPostId(postId)
+                .orElseThrow(() -> new BaseException(LOSTPOST_NOT_FOUND))
+                .deleteBy(userId);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/JpaLostPostDataCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/JpaLostPostDataCommandAdapter.java
@@ -7,6 +7,7 @@ import kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.entity.LostPostEnt
 import kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.repository.LostPostJpaRepository;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataCommandPort;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
+import kr.co.pawong.pwbe.lostPost.enums.PostStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -24,8 +25,16 @@ public class JpaLostPostDataCommandAdapter implements LostPostDataCommandPort {
     }
 
     @Override
-    public void updateDeleteStatus(Long postId, Long userId) {
-        lostPostJpaRepository.getByLostPostId(postId)
+    public LostPost updateLostPostOrThrow(Long postId, LostPost lostPost, Long userId) {
+        return lostPostJpaRepository.findByLostPostIdAndStatus(postId, PostStatus.ACTIVE)
+                .orElseThrow(() -> new BaseException(LOSTPOST_NOT_FOUND))
+                .updateBy(lostPost, userId)
+                .toDomain();
+    }
+
+    @Override
+    public void modifyDeleteStatusOrThrow(Long postId, Long userId) {
+        lostPostJpaRepository.findByLostPostIdAndStatus(postId, PostStatus.ACTIVE)
                 .orElseThrow(() -> new BaseException(LOSTPOST_NOT_FOUND))
                 .deleteBy(userId);
     }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/entity/LostPostEntity.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/entity/LostPostEntity.java
@@ -139,9 +139,27 @@ public class LostPostEntity {
                 .build();
     }
 
-    public void update() {
+    public LostPostEntity updateBy(LostPost lostPost, Long userId) {
+        if(!this.userId.equals(userId)) {
+            throw new BaseException(FORBIDDEN_POST_MODIFY);
+        }
+        this.postType = lostPost.getPostType();
+        this.date = lostPost.getDate();
+        this.upKindNm = lostPost.getUpKindNm();
+        this.upKindCd = lostPost.getUpKindCd();
+        this.kindNm = lostPost.getKindNm();
+        this.color = lostPost.getColor();
+        this.sexCd = lostPost.getSexCd();
+        this.age = lostPost.getAge();
+        this.imageUrl = lostPost.getImageUrl();
+        this.specialMark = lostPost.getSpecialMark();
+        this.content = lostPost.getContent();
+        this.rfidCd = lostPost.getRfidCd();
+        this.location = lostPost.getLocation();
+        this.geoPoint = new GeoPointEmbeddable(lostPost.getGeoPoint());
         this.updatedAt = LocalDateTime.now();
         this.status = PostStatus.ACTIVE;
+        return this;
     }
 
     public void deleteBy(Long userId) {

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/entity/LostPostEntity.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/entity/LostPostEntity.java
@@ -1,5 +1,7 @@
 package kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.entity;
 
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.FORBIDDEN_POST_MODIFY;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -14,6 +16,7 @@ import java.time.LocalDateTime;
 import kr.co.pawong.pwbe.adoption.enums.SexCd;
 import kr.co.pawong.pwbe.adoption.enums.UpKindCd;
 import kr.co.pawong.pwbe.adoption.enums.UpKindNm;
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 import kr.co.pawong.pwbe.lostPost.enums.PostStatus;
 import kr.co.pawong.pwbe.lostPost.enums.PostType;
@@ -135,4 +138,18 @@ public class LostPostEntity {
                 .userId(this.userId)
                 .build();
     }
+
+    public void update() {
+        this.updatedAt = LocalDateTime.now();
+        this.status = PostStatus.ACTIVE;
+    }
+
+    public void deleteBy(Long userId) {
+        if(!this.userId.equals(userId)) {
+            throw new BaseException(FORBIDDEN_POST_MODIFY);
+        }
+        this.deletedAt = LocalDateTime.now();
+        this.status = PostStatus.DELETED;
+    }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/entity/LostPostEntity.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/entity/LostPostEntity.java
@@ -64,7 +64,7 @@ public class LostPostEntity {
     private Integer age;            // 나이
 
     @Column(columnDefinition = "TEXT")
-    private String imageUrl;        // 이미지 url
+    private String imageKey;        // 이미지 Object key
 
     @Column(nullable = false)
     private String specialMark;     // 동물 특징
@@ -100,7 +100,7 @@ public class LostPostEntity {
                 .color(lostPost.getColor())
                 .sexCd(lostPost.getSexCd())
                 .age(lostPost.getAge())
-                .imageUrl(lostPost.getImageUrl())
+                .imageKey(lostPost.getImageKey())
                 .specialMark(lostPost.getSpecialMark())
                 .content(lostPost.getContent())
                 .rfidCd(lostPost.getRfidCd())
@@ -125,7 +125,7 @@ public class LostPostEntity {
                 .color(this.color)
                 .sexCd(this.sexCd)
                 .age(this.age)
-                .imageUrl(this.imageUrl)
+                .imageKey(this.imageKey)
                 .specialMark(this.specialMark)
                 .content(this.content)
                 .rfidCd(this.rfidCd)
@@ -151,7 +151,7 @@ public class LostPostEntity {
         this.color = lostPost.getColor();
         this.sexCd = lostPost.getSexCd();
         this.age = lostPost.getAge();
-        this.imageUrl = lostPost.getImageUrl();
+        this.imageKey = lostPost.getImageKey();
         this.specialMark = lostPost.getSpecialMark();
         this.content = lostPost.getContent();
         this.rfidCd = lostPost.getRfidCd();

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/repository/LostPostJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/repository/LostPostJpaRepository.java
@@ -1,10 +1,13 @@
 package kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.entity.LostPostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LostPostJpaRepository extends JpaRepository<LostPostEntity, Long> {
 
     List<LostPostEntity> findByUserId(Long userId);
+
+    Optional<LostPostEntity> getByLostPostId(Long postId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/repository/LostPostJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/repository/LostPostJpaRepository.java
@@ -3,11 +3,12 @@ package kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.repository;
 import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.lostPost.adapter.out.persistence.jpa.entity.LostPostEntity;
+import kr.co.pawong.pwbe.lostPost.enums.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LostPostJpaRepository extends JpaRepository<LostPostEntity, Long> {
 
     List<LostPostEntity> findByUserId(Long userId);
 
-    Optional<LostPostEntity> getByLostPostId(Long postId);
+    Optional<LostPostEntity> findByLostPostIdAndStatus(Long postId, PostStatus postStatus);
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/CommandLostPostDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/CommandLostPostDataUseCase.java
@@ -5,4 +5,6 @@ import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 public interface CommandLostPostDataUseCase {
 
     Long createLostPost(LostPost lostPost, Long userId);
+
+    void deleteLostPost(Long postId, Long userId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/CommandLostPostDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/CommandLostPostDataUseCase.java
@@ -6,5 +6,7 @@ public interface CommandLostPostDataUseCase {
 
     Long createLostPost(LostPost lostPost, Long userId);
 
+    Long updateLostPost(Long postId, LostPost lostPost, Long userId);
+
     void deleteLostPost(Long postId, Long userId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostCardMapper.java
@@ -21,7 +21,7 @@ public class LostPostCardMapper {
                 .postId(lostPost.getLostPostId())
                 .postType(lostPost.getPostType().name())
                 .author(author)
-                .imageUrl(lostPost.getImageUrl())
+                .imageUrl(lostPost.getImageKey())
                 .happenedDate(TimeUtils.formatDate(lostPost.getDate()))
                 .happenedPlace(lostPost.getLocation())
                 .kindNm(lostPost.getKindNm())

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostPostDataCommandPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostPostDataCommandPort.java
@@ -5,4 +5,7 @@ import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 public interface LostPostDataCommandPort {
 
     LostPost saveLostPost(LostPost LostPost);
+
+    void updateDeleteStatus(Long postId, Long userId);
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostPostDataCommandPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostPostDataCommandPort.java
@@ -6,6 +6,8 @@ public interface LostPostDataCommandPort {
 
     LostPost saveLostPost(LostPost LostPost);
 
-    void updateDeleteStatus(Long postId, Long userId);
+    LostPost updateLostPostOrThrow(Long postId, LostPost lostPost, Long userId);
+
+    void modifyDeleteStatusOrThrow(Long postId, Long userId);
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataService.java
@@ -15,10 +15,10 @@ public class CommandLostPostDataService implements CommandLostPostDataUseCase {
 
     @Override
     public Long createLostPost(LostPost lostPost, Long userId) {
-        lostPost.writtenBy(userId);
-        lostPost.create();
+        lostPost.createBy(userId);
         return lostPostUpdatePort.saveLostPost(lostPost).getLostPostId();
     }
+
 
     @Override
     @Transactional

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataService.java
@@ -5,6 +5,7 @@ import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataCommandPort;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +18,11 @@ public class CommandLostPostDataService implements CommandLostPostDataUseCase {
         lostPost.writtenBy(userId);
         lostPost.create();
         return lostPostUpdatePort.saveLostPost(lostPost).getLostPostId();
+    }
+
+    @Override
+    @Transactional
+    public void deleteLostPost(Long postId, Long userId) {
+        lostPostUpdatePort.updateDeleteStatus(postId, userId);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataService.java
@@ -19,10 +19,15 @@ public class CommandLostPostDataService implements CommandLostPostDataUseCase {
         return lostPostUpdatePort.saveLostPost(lostPost).getLostPostId();
     }
 
+    @Override
+    @Transactional
+    public Long updateLostPost(Long postId, LostPost lostPost, Long userId) {
+        return lostPostUpdatePort.updateLostPostOrThrow(postId, lostPost, userId).getLostPostId();
+    }
 
     @Override
     @Transactional
     public void deleteLostPost(Long postId, Long userId) {
-        lostPostUpdatePort.updateDeleteStatus(postId, userId);
+        lostPostUpdatePort.modifyDeleteStatusOrThrow(postId, userId);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/domain/LostPost.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/domain/LostPost.java
@@ -35,11 +35,8 @@ public class LostPost {
     private GeoPoint geoPoint;
     private Long userId;            // 작성자 유저 id
 
-    public void writtenBy(Long userId) {
+    public void createBy(Long userId) {
         this.userId = userId;
-    }
-
-    public void create() {
         this.createdAt = LocalDateTime.now();
         this.status = PostStatus.ACTIVE;
     }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/domain/LostPost.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/domain/LostPost.java
@@ -43,14 +43,4 @@ public class LostPost {
         this.createdAt = LocalDateTime.now();
         this.status = PostStatus.ACTIVE;
     }
-
-    public void update() {
-        this.updatedAt = LocalDateTime.now();
-        this.status = PostStatus.ACTIVE;
-    }
-
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
-        this.status = PostStatus.DELETED;
-    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/domain/LostPost.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/domain/LostPost.java
@@ -23,7 +23,7 @@ public class LostPost {
     private String color;           // 색상
     private SexCd sexCd;            // 성별
     private Integer age;                // 나이
-    private String imageUrl;        // 이미지 url
+    private String imageKey;        // 이미지 url
     private String specialMark;     // 동물 특징
     private String content;         // 상세 내용
     private String rfidCd;            // 마이크로 칩번호

--- a/src/main/java/kr/co/pawong/pwbe/user/adapter/out/security/filter/JwtFilter.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/adapter/out/security/filter/JwtFilter.java
@@ -41,7 +41,6 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.startsWith("/api/adoptions")
                 || uri.startsWith("/api/adoption")
                 || uri.startsWith("/api/shelters")
-                || uri.startsWith("/api/lost-animals")
                 ;
     }
 

--- a/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/CommandLostPostDataServiceTest.java
@@ -1,0 +1,202 @@
+package kr.co.pawong.pwbe.lostPost.application.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode;
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
+import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataCommandPort;
+import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
+import kr.co.pawong.pwbe.lostPost.domain.LostPost;
+import kr.co.pawong.pwbe.lostPost.enums.PostStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CommandLostPostDataServiceTest {
+
+    @Mock
+    private LostPostDataCommandPort commandPort;
+
+    @Mock
+    private LostPostDataQueryPort queryPort;  // update는 내부에서 안 쓰이지만, 생성자 주입을 위해 선언만
+
+    @InjectMocks
+    private CommandLostPostDataService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * 생성 로직 테스트
+     */
+    @Test
+    void 게시글_생성되면_생성된_ID를_반환한다() {
+        // given
+        LostPost input = LostPost.builder().lostPostId(null).build();
+        LostPost saved = LostPost.builder().lostPostId(123L).build();
+        when(commandPort.saveLostPost(any())).thenReturn(saved);
+
+        // when
+        Long result = service.createLostPost(input, 42L);
+
+        // then
+        assertThat(result).isEqualTo(123L);
+        verify(commandPort, times(1)).saveLostPost(any());  // 1번만 호출됨
+    }
+
+    @Test
+    void 게시글_생성시_userId와_status가_ACTIVE로_설정되어_DB에_전달된다() {
+        // given
+        LostPost input = LostPost.builder().lostPostId(null).build();
+        when(commandPort.saveLostPost(any())).thenReturn(LostPost.builder().build());
+
+        // when
+        service.createLostPost(input, 42L);
+
+        // then
+        ArgumentCaptor<LostPost> captor = ArgumentCaptor.forClass(LostPost.class);
+        verify(commandPort).saveLostPost(captor.capture());
+        LostPost passed = captor.getValue();
+
+        assertThat(passed.getUserId()).isEqualTo(42L);
+        assertThat(passed.getStatus()).isEqualTo(PostStatus.ACTIVE);
+    }
+
+    @Test
+    void 게시글_생성시_createdAt가_설정되어_DB에_전달된다() {
+        // given
+        LostPost input = LostPost.builder().lostPostId(null).build();
+        when(commandPort.saveLostPost(any())).thenReturn(LostPost.builder().build());
+
+        // when
+        service.createLostPost(input, 42L);
+
+        // then
+        ArgumentCaptor<LostPost> captor = ArgumentCaptor.forClass(LostPost.class);
+        verify(commandPort).saveLostPost(captor.capture());
+        LostPost passed = captor.getValue();
+
+        assertThat(passed.getCreatedAt()).isNotNull();
+    }
+
+    /**
+     * 수정 로직 테스트
+     */
+    @Test
+    void 게시글_수정요청하면_updateLostPostOrThrow를_호출한다() {
+        // given
+        Long postId = 7L, userId = 99L;
+        LostPost dto = LostPost.builder().lostPostId(postId).build();
+        LostPost dummyResult = LostPost.builder().lostPostId(postId).build();
+        when(commandPort.updateLostPostOrThrow(postId, dto, userId))
+                .thenReturn(dummyResult);
+
+        // when
+        service.updateLostPost(postId, dto, userId);
+
+        // then
+        verify(commandPort, times(1))
+                .updateLostPostOrThrow(postId, dto, userId);
+    }
+
+    @Test
+    void 게시글_수정요청하면_포트가_반환한_ID를_리턴한다() {
+        // given
+        Long postId = 7L, userId = 99L;
+        LostPost dto = LostPost.builder().lostPostId(postId).build();
+        LostPost updated = LostPost.builder().lostPostId(888L).build();
+        when(commandPort.updateLostPostOrThrow(postId, dto, userId))
+                .thenReturn(updated);
+
+        // when
+        Long result = service.updateLostPost(postId, dto, userId);
+
+        // then
+        assertThat(result).isEqualTo(888L);
+    }
+    @Test
+    void updateLostPost_존재하지_않는_게시글이면_NotFound_예외_던진다() {
+        // given
+        Long postId = 1L, userId = 2L;
+        LostPost dto = LostPost.builder().lostPostId(postId).build();
+        doThrow(new BaseException(CustomErrorCode.LOSTPOST_NOT_FOUND))
+                .when(commandPort).updateLostPostOrThrow(postId, dto, userId);
+
+        // when / then
+        BaseException ex = assertThrows(BaseException.class,
+                () -> service.updateLostPost(postId, dto, userId));
+
+        // then
+        assertThat(ex.getErrorCode()).isEqualTo(CustomErrorCode.LOSTPOST_NOT_FOUND);
+    }
+    @Test
+    void updateLostPost_작성자가_아니면_Forbidden_예외_던진다() {
+        // given
+        Long postId = 3L, userId = 4L;
+        LostPost dto = LostPost.builder().lostPostId(postId).build();
+        doThrow(new BaseException(CustomErrorCode.FORBIDDEN_POST_MODIFY))
+                .when(commandPort).updateLostPostOrThrow(postId, dto, userId);
+
+        // when / then
+        BaseException ex = assertThrows(BaseException.class,
+                () -> service.updateLostPost(postId, dto, userId));
+
+        assertThat(ex.getErrorCode()).isEqualTo(CustomErrorCode.FORBIDDEN_POST_MODIFY);
+    }
+
+    /**
+     * 삭제 로직 테스트
+     */
+    @Test
+    void 게시글_삭제요청하면_modifyDeleteStatusOrThrow를_호출한다() {
+        // given
+        Long postId = 55L, userId = 66L;
+
+        // when
+        service.deleteLostPost(postId, userId);
+
+        // then
+        verify(commandPort, times(1))
+                .modifyDeleteStatusOrThrow(postId, userId);
+    }
+
+    @Test
+    void deleteLostPost_존재하지_않는_게시글이면_NotFound_예외_던진다() {
+        // given
+        Long postId = 5L, userId = 6L;
+        doThrow(new BaseException(CustomErrorCode.LOSTPOST_NOT_FOUND))
+                .when(commandPort).modifyDeleteStatusOrThrow(postId, userId);
+
+        // when / then
+        BaseException ex = assertThrows(BaseException.class,
+                () -> service.deleteLostPost(postId, userId));
+
+        assertThat(ex.getErrorCode()).isEqualTo(CustomErrorCode.LOSTPOST_NOT_FOUND);
+    }
+
+    @Test
+    void deleteLostPost_작성자가_아니면_Forbidden_예외_던진다() {
+        // given
+        Long postId = 7L, userId = 8L;
+        doThrow(new BaseException(CustomErrorCode.FORBIDDEN_POST_MODIFY))
+                .when(commandPort).modifyDeleteStatusOrThrow(postId, userId);
+
+        // when / then
+        BaseException ex = assertThrows(BaseException.class,
+                () -> service.deleteLostPost(postId, userId));
+
+        assertThat(ex.getErrorCode()).isEqualTo(CustomErrorCode.FORBIDDEN_POST_MODIFY);
+    }
+
+}


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#22 -> develop

### 변경 사항

1. 실종동물 게시글 수정 API

- LostPostUpdateRequest -> LostPost 매핑(lostPostId가 null인 상태)
- lostPostId로 DB에서 LostPostEntity 조회
- LostPostEntity 내부 updateBy메소드에 의해서 작성자 validation 및 필드값 업데이트 (더티 체킹)
- 수정날짜를 변경하고 포스트 status를 `ACTIVE`로 다시 덮습니다
- 작성자와 수정자가 다르면 `FORBIDDEN_POST_MODIFY` 에러 반환
- LostPostEntity가 없으면 `LOSTPOST_NOT_FOUND` 에러 반환


2. 실종동물 게시글 삭제 API

- 삭제한 게시글 lostPostId를 쿼리스트링으로 받습니다
- lostPostId로 DB에서 LostPostEntity 조회
- LostPostEntity 내부 deleteBy 메소드에 의해 작성자 validation 및 필드값 업데이트 (더티 체킹)
- 삭제날짜와 삭제status를 `DELETE`로 변경합니다
- 작성자와 삭제자가 다르면 `FORBIDDEN_POST_MODIFY` 에러 반환
- LostPostEntity가 없으면 `LOSTPOST_NOT_FOUND` 에러 반환


3. 실종동물 command controller에서 uri 수정
- `/api/lost-posts` -> `/api/lost-animals/lost-posts` 로 변경했습니다


### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과

