### PR TITLE
[PW-21] shelter에 없는 보호소 정보 adoption에서 가져와 DB에 저장 로직 구현

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/processor/AdoptionApiProcessor.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/processor/AdoptionApiProcessor.java
@@ -1,7 +1,7 @@
 package kr.co.pawong.pwbe.adoption.adapter.in.batch.processor;
 
 import kr.co.pawong.pwbe.adoption.application.port.in.ApiAdoptionUseCase;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/processor/AdoptionApiProcessor.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/processor/AdoptionApiProcessor.java
@@ -16,9 +16,9 @@ public class AdoptionApiProcessor implements ItemProcessor<AdoptionApi.Item, Ado
 
     @Override
     public AdoptionCreate process(AdoptionApi.Item item) {
-//        // 보호소 정보 추출 및 처리
-//        apiRequestUseCase.extractAndProcessShelterInfo(item);
-//        log.debug("보호소 정보 처리 완료: careRegNo={}", item.getCareRegNo());
+        // 보호소 정보 추출 및 처리
+        apiRequestUseCase.extractAndProcessShelterInfo(item);
+        log.debug("보호소 정보 처리 완료: careRegNo={}", item.getCareRegNo());
 
         return apiRequestUseCase.convertToAdoptionCreate(item);
     }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/processor/AdoptionApiProcessor.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/processor/AdoptionApiProcessor.java
@@ -1,6 +1,6 @@
 package kr.co.pawong.pwbe.adoption.adapter.in.batch.processor;
 
-import kr.co.pawong.pwbe.adoption.application.port.in.ApiRequestUseCase;
+import kr.co.pawong.pwbe.adoption.application.port.in.ApiAdoptionUseCase;
 import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +12,14 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class AdoptionApiProcessor implements ItemProcessor<AdoptionApi.Item, AdoptionCreate> {
-    private final ApiRequestUseCase apiRequestUseCase;
+    private final ApiAdoptionUseCase apiAdoptionUseCase;
 
     @Override
     public AdoptionCreate process(AdoptionApi.Item item) {
         // 보호소 정보 추출 및 처리
-        apiRequestUseCase.extractAndProcessShelterInfo(item);
+        apiAdoptionUseCase.extractAndProcessShelterInfo(item);
         log.debug("보호소 정보 처리 완료: careRegNo={}", item.getCareRegNo());
 
-        return apiRequestUseCase.convertToAdoptionCreate(item);
+        return apiAdoptionUseCase.convertToAdoptionCreate(item);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/reader/AdoptionApiReader.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/reader/AdoptionApiReader.java
@@ -1,6 +1,6 @@
 package kr.co.pawong.pwbe.adoption.adapter.in.batch.reader;
 
-import kr.co.pawong.pwbe.adoption.application.port.in.ApiRequestUseCase;
+import kr.co.pawong.pwbe.adoption.application.port.in.ApiAdoptionUseCase;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Component;
 @StepScope
 @RequiredArgsConstructor
 public class AdoptionApiReader implements ItemReader<AdoptionApi.Item> {
-    private final ApiRequestUseCase apiRequestUseCase;
+    private final ApiAdoptionUseCase apiAdoptionUseCase;
 
     @Override
     public AdoptionApi.Item read() {
-        return apiRequestUseCase.fetchNextAdoptionItem();
+        return apiAdoptionUseCase.fetchNextAdoptionItem();
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/writer/AdoptionApiWriter.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/in/batch/writer/AdoptionApiWriter.java
@@ -3,7 +3,7 @@ package kr.co.pawong.pwbe.adoption.adapter.in.batch.writer;
 import java.util.ArrayList;
 import java.util.List;
 import kr.co.pawong.pwbe.adoption.application.port.in.CommandAdoptionDataUseCase;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/persistence/jpa/JpaAdoptionDataCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/persistence/jpa/JpaAdoptionDataCommandAdapter.java
@@ -1,11 +1,14 @@
 package kr.co.pawong.pwbe.adoption.adapter.out.persistence.jpa;
 
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.ADOPTION_NOT_FOUND;
+
 import jakarta.transaction.Transactional;
 import java.util.List;
-import kr.co.pawong.pwbe.adoption.domain.model.Adoption;
-import kr.co.pawong.pwbe.adoption.application.port.out.AdoptionDataCommandPort;
-import kr.co.pawong.pwbe.adoption.adapter.out.persistence.jpa.repository.AdoptionJpaRepository;
 import kr.co.pawong.pwbe.adoption.adapter.out.persistence.jpa.entity.AdoptionEntity;
+import kr.co.pawong.pwbe.adoption.adapter.out.persistence.jpa.repository.AdoptionJpaRepository;
+import kr.co.pawong.pwbe.adoption.application.port.out.AdoptionDataCommandPort;
+import kr.co.pawong.pwbe.adoption.domain.model.Adoption;
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
@@ -49,7 +52,7 @@ public class JpaAdoptionDataCommandAdapter implements AdoptionDataCommandPort {
         // desertionNo로 entity 조회
         AdoptionEntity adoptionEntity = adoptionJpaRepository.findByDesertionNo(
                 adoption.getDesertionNo())
-                .orElseThrow(() -> new IllegalArgumentException("해당 유기동물 정보가 존재하지 않습니다.: " + adoption.getDesertionNo()));
+                .orElseThrow(() -> new BaseException(ADOPTION_NOT_FOUND));
 
         // 업데이트 (더티 체킹)
         adoptionEntity.update(adoption);

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/shelter/ShelterCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/shelter/ShelterCommandAdapter.java
@@ -1,0 +1,27 @@
+package kr.co.pawong.pwbe.adoption.adapter.out.shelter;
+
+import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.adoption.application.port.out.ShelterCommandPort;
+import kr.co.pawong.pwbe.shelter.application.port.in.UpdateShelterDataUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShelterCommandAdapter implements ShelterCommandPort {
+
+    private final UpdateShelterDataUseCase updateShelterDataUseCase;
+
+    @Override
+    public void processShelterInfo(AdoptionCareDto adoptionCareDto) {
+        try {
+            updateShelterDataUseCase.updateShelterIfNotExist(adoptionCareDto);
+        } catch (Exception e) {
+            log.error("ShelterCommandAdapter - 보호소 정보 처리 중 오류 발생: careRegNo={}, error={}",
+                    adoptionCareDto.getCareRegNo(), e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/shelter/ShelterCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/shelter/ShelterCommandAdapter.java
@@ -1,6 +1,6 @@
 package kr.co.pawong.pwbe.adoption.adapter.out.shelter;
 
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
 import kr.co.pawong.pwbe.adoption.application.port.out.ShelterCommandPort;
 import kr.co.pawong.pwbe.shelter.application.port.in.UpdateShelterDataUseCase;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/shelter/ShelterCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/adapter/out/shelter/ShelterCommandAdapter.java
@@ -16,12 +16,6 @@ public class ShelterCommandAdapter implements ShelterCommandPort {
 
     @Override
     public void processShelterInfo(AdoptionCareDto adoptionCareDto) {
-        try {
-            updateShelterDataUseCase.updateShelterIfNotExist(adoptionCareDto);
-        } catch (Exception e) {
-            log.error("ShelterCommandAdapter - 보호소 정보 처리 중 오류 발생: careRegNo={}, error={}",
-                    adoptionCareDto.getCareRegNo(), e.getMessage(), e);
-            throw e;
-        }
+        updateShelterDataUseCase.updateShelterIfNotExist(adoptionCareDto);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/ApiAdoptionUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/ApiAdoptionUseCase.java
@@ -1,6 +1,6 @@
 package kr.co.pawong.pwbe.adoption.application.port.in;
 
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 
 public interface ApiAdoptionUseCase {

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/ApiAdoptionUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/ApiAdoptionUseCase.java
@@ -3,7 +3,7 @@ package kr.co.pawong.pwbe.adoption.application.port.in;
 import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 
-public interface ApiRequestUseCase {
+public interface ApiAdoptionUseCase {
 
     AdoptionCreate convertToAdoptionCreate(AdoptionApi.Item item);
 

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/ApiRequestUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/ApiRequestUseCase.java
@@ -8,4 +8,6 @@ public interface ApiRequestUseCase {
     AdoptionCreate convertToAdoptionCreate(AdoptionApi.Item item);
 
     AdoptionApi.Item fetchNextAdoptionItem();
+
+    void extractAndProcessShelterInfo(AdoptionApi.Item item);
 }

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/CommandAdoptionDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/CommandAdoptionDataUseCase.java
@@ -1,7 +1,7 @@
 package kr.co.pawong.pwbe.adoption.application.port.in;
 
 import java.util.List;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.domain.model.Adoption;
 
 public interface CommandAdoptionDataUseCase {

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/dto/AdoptionCareDto.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/in/dto/AdoptionCareDto.java
@@ -1,0 +1,29 @@
+package kr.co.pawong.pwbe.adoption.application.port.in.dto;
+
+import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdoptionCareDto {
+    private String careRegNo; // 보호소 번호
+    private String careNm; // 보호소 이름
+    private String careTel; // 보호소 전화번호
+    private String careAddr; // 보호 장소
+    private String orgNm;
+
+    public static AdoptionCareDto from(AdoptionApi.Item item){
+        return AdoptionCareDto.builder()
+                .careRegNo(item.getCareRegNo())
+                .careNm(item.getCareNm())
+                .careTel(item.getCareTel())
+                .careAddr(item.getCareAddr())
+                .orgNm(item.getOrgNm())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/out/ShelterCommandPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/out/ShelterCommandPort.java
@@ -1,6 +1,6 @@
 package kr.co.pawong.pwbe.adoption.application.port.out;
 
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
 
 public interface ShelterCommandPort {
 

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/out/ShelterCommandPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/out/ShelterCommandPort.java
@@ -1,0 +1,9 @@
+package kr.co.pawong.pwbe.adoption.application.port.out;
+
+import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+
+public interface ShelterCommandPort {
+
+    void processShelterInfo(AdoptionCareDto adoptionCareDto);
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/port/out/dto/AdoptionCareDto.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/port/out/dto/AdoptionCareDto.java
@@ -1,4 +1,4 @@
-package kr.co.pawong.pwbe.adoption.application.port.in.dto;
+package kr.co.pawong.pwbe.adoption.application.port.out.dto;
 
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 import lombok.AllArgsConstructor;

--- a/src/main/java/kr/co/pawong/pwbe/adoption/application/service/CommandAdoptionDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/application/service/CommandAdoptionDataService.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import kr.co.pawong.pwbe.adoption.application.port.in.CommandAdoptionDataUseCase;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.port.out.AdoptionAiPort;
 import kr.co.pawong.pwbe.adoption.application.port.out.AdoptionDataCommandPort;
 import kr.co.pawong.pwbe.adoption.application.port.out.AdoptionDataQueryPort;

--- a/src/main/java/kr/co/pawong/pwbe/adoption/domain/model/Adoption.java
+++ b/src/main/java/kr/co/pawong/pwbe/adoption/domain/model/Adoption.java
@@ -2,7 +2,7 @@ package kr.co.pawong.pwbe.adoption.domain.model;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionUpdate;
 import kr.co.pawong.pwbe.adoption.enums.ActiveState;
 import kr.co.pawong.pwbe.adoption.enums.NeuterYn;

--- a/src/main/java/kr/co/pawong/pwbe/global/config/AdoptionBatchConfig.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/config/AdoptionBatchConfig.java
@@ -9,7 +9,7 @@ import kr.co.pawong.pwbe.adoption.adapter.in.batch.reader.AdoptionEsReader;
 import kr.co.pawong.pwbe.adoption.adapter.in.batch.writer.AdoptionAiWriter;
 import kr.co.pawong.pwbe.adoption.adapter.in.batch.writer.AdoptionApiWriter;
 import kr.co.pawong.pwbe.adoption.adapter.in.batch.writer.AdoptionEsWriter;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionEsDto;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 import kr.co.pawong.pwbe.adoption.domain.model.Adoption;

--- a/src/main/java/kr/co/pawong/pwbe/global/util/ApiDataUtils.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/util/ApiDataUtils.java
@@ -1,0 +1,73 @@
+package kr.co.pawong.pwbe.global.util;
+
+import groovy.util.logging.Slf4j;
+
+@Slf4j
+public class ApiDataUtils {
+
+    // 문자열 -> 정수 (나이)
+    public static Integer parseIntAge(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
+        try {
+            String age = value.substring(0, 4);
+            return Integer.parseInt(age);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    // 문자열 -> Integer
+   public static Integer parseInt(String value, Integer defaultValue) {
+        if (value == null || value.trim().isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    // 문자열 -> double
+    public static Double parseDouble(String value, Double defaultValue) {
+        if (value == null || value.trim().isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    // 문자열 -> Enum
+    public static <T extends Enum<T>> T convertToEnum(String data, Class<T> enumClass) {
+        if (data == null) {
+            return null;
+        }
+
+        try {
+            return Enum.valueOf(enumClass, data);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    // 주소 -> 시도, 시군구
+    public static String[] parseAddress(String careAddr) {
+        String[] result = new String[2]; // [0] = city, [1] = district
+
+        if (careAddr != null && !careAddr.isEmpty()) {
+            String[] parts = careAddr.split(" ");
+            if (parts.length >= 2) {
+                result[0] = parts[0]; // city
+                result[1] = parts[1]; // district
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/global/util/TimeUtils.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/util/TimeUtils.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 
 public class TimeUtils {
@@ -72,5 +73,30 @@ public class TimeUtils {
         long days   = ChronoUnit.DAYS.between(past, today);
         if (days > 0) return days + "일 전";
         return "오늘";
+    }
+
+    // 문자열 -> LocalDate
+    public static LocalDate parseLocalDate(String date, DateTimeFormatter formatter) {
+        if (date != null && !date.isEmpty()) {
+            try {
+                return LocalDate.parse(date, formatter);
+            } catch (DateTimeParseException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    // 문자열 -> LocalDateTime
+    public static LocalDateTime parseLocalDateTime(String date, DateTimeFormatter formatter) {
+        if (date != null && !date.isEmpty()) {
+            try {
+                return LocalDateTime.parse(date, formatter)
+                        .truncatedTo(ChronoUnit.SECONDS);
+            } catch (DateTimeParseException e) {
+                return null;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
@@ -13,7 +13,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.adoption.application.port.in.ApiRequestUseCase;
+import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
 import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.adoption.application.port.out.ShelterCommandPort;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi.Body;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi.Items;
@@ -41,6 +43,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class ApiAdoptionService implements ApiRequestUseCase {
 
     private final RestTemplate restTemplate;
+    private final ShelterCommandPort shelterCommandPort;
 
     @Value("${api.service-key}")
     private String serviceKey;
@@ -172,6 +175,21 @@ public class ApiAdoptionService implements ApiRequestUseCase {
                 .map(Items::getItem)
                 .filter(items -> !items.isEmpty())
                 .isPresent();
+    }
+
+    @Override
+    public void extractAndProcessShelterInfo(AdoptionApi.Item item) {
+        try {
+            // 보호소 정보 추출
+            AdoptionCareDto adoptionCareDto = AdoptionCareDto.from(item);
+
+            // 추출한 정보 처리
+            shelterCommandPort.processShelterInfo(adoptionCareDto);
+        } catch (Exception e) {
+            log.error("보호소 정보 처리 중 오류 발생: careRegNo={}, error={}",
+                    item.getCareRegNo(), e.getMessage(), e);
+            throw e;
+        }
     }
 }
 

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
@@ -1,11 +1,14 @@
 package kr.co.pawong.pwbe.infrastructure.api;
 
+import static kr.co.pawong.pwbe.global.util.ApiDataUtils.convertToEnum;
+import static kr.co.pawong.pwbe.global.util.ApiDataUtils.parseIntAge;
+import static kr.co.pawong.pwbe.global.util.TimeUtils.parseLocalDate;
+import static kr.co.pawong.pwbe.global.util.TimeUtils.parseLocalDateTime;
+
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +38,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ApiRequestService implements ApiRequestUseCase {
+public class ApiAdoptionService implements ApiRequestUseCase {
 
     private final RestTemplate restTemplate;
 
@@ -160,67 +163,15 @@ public class ApiRequestService implements ApiRequestUseCase {
         return adoptionCreate;
     }
 
-// API 응답 데이터의 유효성을 검사
-private boolean isValidAdoptionData(AdoptionApi adoptionApi) {
-    return Optional.ofNullable(adoptionApi)
-            .map(AdoptionApi::getResponse)
-            .map(Response::getBody)
-            .map(Body::getItems)
-            .map(Items::getItem)
-            .filter(items -> !items.isEmpty())
-            .isPresent();
-}
-
-    // 문자열 -> LocalDate
-    private LocalDate parseLocalDate(String date, DateTimeFormatter formatter) {
-        if (date != null && !date.isEmpty()) {
-            try {
-                return LocalDate.parse(date, formatter);
-            } catch (DateTimeParseException e) {
-                log.error("날짜 파싱 오류 ({}): {}", date, e.getMessage());
-            }
-        }
-        return null;
-    }
-
-    // 문자열 -> LocalDateTime
-    private LocalDateTime parseLocalDateTime(String date, DateTimeFormatter formatter) {
-        if (date != null && !date.isEmpty()) {
-            try {
-                return LocalDateTime.parse(date, formatter)
-                        .truncatedTo(ChronoUnit.SECONDS);
-            } catch (DateTimeParseException e) {
-                log.error("날짜 시간 파싱 오류 ({}): {}", date, e.getMessage());
-            }
-        }
-        return null;
-    }
-
-    // 문자열 -> 정수
-    private Integer parseIntAge(String value) {
-        if (value == null || value.isEmpty()) {
-            return null;
-        }
-
-        try {
-            String age = value.substring(0, 4);
-            return Integer.parseInt(age);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    // 문자열 -> Enum
-    private <T extends Enum<T>> T convertToEnum(String data, Class<T> enumClass) {
-        if (data == null) {
-            return null;
-        }
-
-        try {
-            return Enum.valueOf(enumClass, data);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+    // API 응답 데이터의 유효성을 검사
+    private boolean isValidAdoptionData(AdoptionApi adoptionApi) {
+        return Optional.ofNullable(adoptionApi)
+                .map(AdoptionApi::getResponse)
+                .map(Response::getBody)
+                .map(Body::getItems)
+                .map(Items::getItem)
+                .filter(items -> !items.isEmpty())
+                .isPresent();
     }
 }
 

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.adoption.application.port.in.ApiAdoptionUseCase;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
 import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.port.out.ShelterCommandPort;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.adoption.application.port.in.ApiAdoptionUseCase;
 import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.port.out.ShelterCommandPort;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi;
 import kr.co.pawong.pwbe.adoption.application.service.dto.AdoptionApi.Body;

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import kr.co.pawong.pwbe.adoption.application.port.in.ApiRequestUseCase;
+import kr.co.pawong.pwbe.adoption.application.port.in.ApiAdoptionUseCase;
 import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
 import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCreate;
 import kr.co.pawong.pwbe.adoption.application.port.out.ShelterCommandPort;
@@ -40,7 +40,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ApiAdoptionService implements ApiRequestUseCase {
+public class ApiAdoptionService implements ApiAdoptionUseCase {
 
     private final RestTemplate restTemplate;
     private final ShelterCommandPort shelterCommandPort;

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiAdoptionService.java
@@ -179,17 +179,11 @@ public class ApiAdoptionService implements ApiAdoptionUseCase {
 
     @Override
     public void extractAndProcessShelterInfo(AdoptionApi.Item item) {
-        try {
-            // 보호소 정보 추출
-            AdoptionCareDto adoptionCareDto = AdoptionCareDto.from(item);
+        // 보호소 정보 추출
+        AdoptionCareDto adoptionCareDto = AdoptionCareDto.from(item);
 
-            // 추출한 정보 처리
-            shelterCommandPort.processShelterInfo(adoptionCareDto);
-        } catch (Exception e) {
-            log.error("보호소 정보 처리 중 오류 발생: careRegNo={}, error={}",
-                    item.getCareRegNo(), e.getMessage(), e);
-            throw e;
-        }
+        // 추출한 정보 처리
+        shelterCommandPort.processShelterInfo(adoptionCareDto);
     }
 }
 

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiShelterService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiShelterService.java
@@ -15,7 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.ShelterCreate;
 import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataCommandPort;
 import kr.co.pawong.pwbe.shelter.application.service.dto.ShelterApi;
 import kr.co.pawong.pwbe.shelter.enums.DivisionNm;

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiShelterService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiShelterService.java
@@ -42,7 +42,7 @@ public class ApiShelterService {
     @Value("${api.service-key}")
     private String serviceKey;
 
-    @Value("${api-url.shelter-key}")
+    @Value("${api-url.shelter}")
     private String apiUrl;
 
     public List<ShelterCreate> saveShelters() {

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiShelterService.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/ApiShelterService.java
@@ -1,4 +1,4 @@
-package kr.co.pawong.pwbe.shelter.application.service;
+package kr.co.pawong.pwbe.infrastructure.api;
 
 import static kr.co.pawong.pwbe.global.util.ApiDataUtils.convertToEnum;
 import static kr.co.pawong.pwbe.global.util.ApiDataUtils.parseAddress;
@@ -43,6 +43,7 @@ public class ApiShelterService {
     private String serviceKey;
 
     @Value("${api-url.shelter-key}")
+    private String apiUrl;
 
     public List<ShelterCreate> saveShelters() {
         List<ShelterCreate> allShelterCreates = new ArrayList<>();
@@ -56,8 +57,7 @@ public class ApiShelterService {
 
         while (hasMoreData) {
 
-            URI uri = UriComponentsBuilder.fromHttpUrl(
-                            "https://apis.data.go.kr/1543061/animalShelterSrvc_v2/shelterInfo_v2")
+            URI uri = UriComponentsBuilder.fromHttpUrl(apiUrl)
                     .queryParam("serviceKey", serviceKey)
                     .queryParam("numOfRows", numOfRows)
                     .queryParam("pageNo", pageNo)

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/dto/AdoptionCreate.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/dto/AdoptionCreate.java
@@ -1,4 +1,4 @@
-package kr.co.pawong.pwbe.adoption.application.port.in.dto;
+package kr.co.pawong.pwbe.infrastructure.api.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/api/dto/ShelterCreate.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/api/dto/ShelterCreate.java
@@ -1,4 +1,4 @@
-package kr.co.pawong.pwbe.shelter.application.port.in.dto;
+package kr.co.pawong.pwbe.infrastructure.api.dto;
 
 import kr.co.pawong.pwbe.shelter.enums.DivisionNm;
 import kr.co.pawong.pwbe.shelter.adapter.out.persistence.jpa.entity.ShelterEntity;

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostDetailMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/in/mapper/LostPostDetailMapper.java
@@ -18,7 +18,7 @@ public class LostPostDetailMapper {
                 .color(lostPost.getColor())
                 .sexCd(lostPost.getSexCd())
                 .age(lostPost.getAge())
-                .imageUrl(lostPost.getImageUrl())
+                .imageUrl(lostPost.getImageKey())
                 .specialMark(lostPost.getSpecialMark())
                 .content(lostPost.getContent())
                 .rfidCd(lostPost.getRfidCd())

--- a/src/main/java/kr/co/pawong/pwbe/shelter/adapter/in/api/ShelterUpdateController.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/adapter/in/api/ShelterUpdateController.java
@@ -1,7 +1,7 @@
 package kr.co.pawong.pwbe.shelter.adapter.in.api;
 
 import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
-import kr.co.pawong.pwbe.shelter.application.service.ApiShelterService;
+import kr.co.pawong.pwbe.infrastructure.api.ApiShelterService;
 import kr.co.pawong.pwbe.shelter.application.port.in.UpdateShelterDataUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/kr/co/pawong/pwbe/shelter/adapter/in/api/ShelterUpdateController.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/adapter/in/api/ShelterUpdateController.java
@@ -1,6 +1,6 @@
 package kr.co.pawong.pwbe.shelter.adapter.in.api;
 
-import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.ShelterCreate;
 import kr.co.pawong.pwbe.infrastructure.api.ApiShelterService;
 import kr.co.pawong.pwbe.shelter.application.port.in.UpdateShelterDataUseCase;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/JpaShelterDataCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/JpaShelterDataCommandAdapter.java
@@ -26,6 +26,7 @@ public class JpaShelterDataCommandAdapter implements ShelterDataCommandPort {
         shelterJpaRepository.saveAll(shelterEntities);
         log.info("{}개의 보호소 정보가 저장되었습니다.", shelters.size());
     }
+
     @Override
     public List<String> findAllCareRegNos() {
         return shelterJpaRepository.findAllCareRegNos();
@@ -33,15 +34,11 @@ public class JpaShelterDataCommandAdapter implements ShelterDataCommandPort {
 
     @Override
     public void saveShelter(Shelter shelter) {
-        try {
-            ShelterEntity shelterEntity = ShelterEntity.from(shelter);
-            shelterJpaRepository.save(shelterEntity);
-            log.info("보호소 정보 저장 완료: id={}, careRegNo={}, name={}",
-                    shelterEntity.getShelterId(), shelterEntity.getCareRegNo(), shelterEntity.getCareNm());
-        } catch (Exception e) {
-            log.error("보호소 정보 저장 중 오류 발생: careRegNo={}, error={}",
-                    shelter.getCareRegNo(), e.getMessage(), e);
-            throw e;
-        }
+
+        ShelterEntity shelterEntity = ShelterEntity.from(shelter);
+        shelterJpaRepository.save(shelterEntity);
+        log.info("보호소 정보 저장 완료: id={}, careRegNo={}, name={}",
+                shelterEntity.getShelterId(), shelterEntity.getCareRegNo(),
+                shelterEntity.getCareNm());
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/JpaShelterDataCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/JpaShelterDataCommandAdapter.java
@@ -31,4 +31,17 @@ public class JpaShelterDataCommandAdapter implements ShelterDataCommandPort {
         return shelterJpaRepository.findAllCareRegNos();
     }
 
+    @Override
+    public void saveShelter(Shelter shelter) {
+        try {
+            ShelterEntity shelterEntity = ShelterEntity.from(shelter);
+            shelterJpaRepository.save(shelterEntity);
+            log.info("보호소 정보 저장 완료: id={}, careRegNo={}, name={}",
+                    shelterEntity.getShelterId(), shelterEntity.getCareRegNo(), shelterEntity.getCareNm());
+        } catch (Exception e) {
+            log.error("보호소 정보 저장 중 오류 발생: careRegNo={}, error={}",
+                    shelter.getCareRegNo(), e.getMessage(), e);
+            throw e;
+        }
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/JpaShelterDataQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/JpaShelterDataQueryAdapter.java
@@ -21,4 +21,11 @@ public class JpaShelterDataQueryAdapter implements ShelterDataQueryPort {
                 .map(ShelterEntity::toModel)
                 .orElse(null);
     }
+
+    @Override
+    public boolean existsByCareRegNo(String careRegNo) {
+        return shelterJpaRepository.existsByCareRegNo(careRegNo);
+    }
+
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/repository/ShelterJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/adapter/out/persistence/jpa/repository/ShelterJpaRepository.java
@@ -19,4 +19,6 @@ public interface ShelterJpaRepository extends JpaRepository<ShelterEntity, Long>
     List<String> findAllCareRegNos();
 
     Optional<ShelterEntity> findByCareRegNo(String careRegNo);
+
+    boolean existsByCareRegNo(String careRegNo);
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/port/in/UpdateShelterDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/port/in/UpdateShelterDataUseCase.java
@@ -1,7 +1,7 @@
 package kr.co.pawong.pwbe.shelter.application.port.in;
 
 import java.util.List;
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
 import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
 
 

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/port/in/UpdateShelterDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/port/in/UpdateShelterDataUseCase.java
@@ -2,7 +2,7 @@ package kr.co.pawong.pwbe.shelter.application.port.in;
 
 import java.util.List;
 import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
-import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.ShelterCreate;
 
 
 public interface UpdateShelterDataUseCase {

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/port/in/UpdateShelterDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/port/in/UpdateShelterDataUseCase.java
@@ -1,11 +1,14 @@
 package kr.co.pawong.pwbe.shelter.application.port.in;
 
-import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
 import java.util.List;
+import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
 
 
 public interface UpdateShelterDataUseCase {
     // ShelterCreate -> Shelter
     void saveShelters(List<ShelterCreate> shelterCreates);
+
+    void updateShelterIfNotExist(AdoptionCareDto adoptionCareDto);
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/port/out/ShelterDataCommandPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/port/out/ShelterDataCommandPort.java
@@ -10,4 +10,6 @@ public interface ShelterDataCommandPort {
 
     List<String> findAllCareRegNos();
 
+    void saveShelter(Shelter shelter);
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/port/out/ShelterDataQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/port/out/ShelterDataQueryPort.java
@@ -6,4 +6,8 @@ import kr.co.pawong.pwbe.shelter.domain.Shelter;
 public interface ShelterDataQueryPort {
 
     Shelter findByCareRegNoOrThrow(String careRegNo);
+
+    boolean existsByCareRegNo(String careRegNo);
+
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
@@ -1,18 +1,17 @@
 package kr.co.pawong.pwbe.shelter.application.service;
 
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import java.util.List;
+import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.shelter.application.port.in.UpdateShelterDataUseCase;
+import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
+import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataCommandPort;
 import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataQueryPort;
 import kr.co.pawong.pwbe.shelter.application.service.support.ShelterMapper;
 import kr.co.pawong.pwbe.shelter.domain.Shelter;
-import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
-import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataCommandPort;
-import kr.co.pawong.pwbe.shelter.application.port.in.UpdateShelterDataUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -24,8 +23,8 @@ public class UpdateShelterDataService implements UpdateShelterDataUseCase {
     private final ShelterMapper shelterMapper;
 
     // ShelterCreate -> Shelter -> Repo에 전달
-    @Transactional
     @Override
+    @Transactional
     public void saveShelters(List<ShelterCreate> shelterCreates) {
         List<Shelter> shelters = shelterCreates.stream()
                 .map(Shelter::from)
@@ -35,6 +34,7 @@ public class UpdateShelterDataService implements UpdateShelterDataUseCase {
     }
 
     @Override
+    @Transactional
     public void updateShelterIfNotExist(AdoptionCareDto adoptionCareDto) {
         String careRegNo = adoptionCareDto.getCareRegNo();
         try {

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
@@ -1,5 +1,8 @@
 package kr.co.pawong.pwbe.shelter.application.service;
 
+import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataQueryPort;
+import kr.co.pawong.pwbe.shelter.application.service.support.ShelterMapper;
 import kr.co.pawong.pwbe.shelter.domain.Shelter;
 import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
 import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataCommandPort;
@@ -16,7 +19,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UpdateShelterDataService implements UpdateShelterDataUseCase {
 
+    private final ShelterDataQueryPort shelterDataQueryPort;
     private final ShelterDataCommandPort shelterDataCommandPort;
+    private final ShelterMapper shelterMapper;
 
     // ShelterCreate -> Shelter -> Repo에 전달
     @Transactional
@@ -27,5 +32,25 @@ public class UpdateShelterDataService implements UpdateShelterDataUseCase {
                 .toList();
 
         shelterDataCommandPort.saveShelters(shelters);
+    }
+
+    @Override
+    public void updateShelterIfNotExist(AdoptionCareDto adoptionCareDto) {
+        String careRegNo = adoptionCareDto.getCareRegNo();
+        try {
+            // 보호소 번호로 기존 보호소 검색
+            boolean exists = shelterDataQueryPort.existsByCareRegNo(careRegNo);
+
+            // 보호소가 존재하지 않는 경우에만 새로 저장
+            if (!exists) {
+                // 매퍼를 사용하여 DTO를 도메인 객체로 변환
+                Shelter shelter = shelterMapper.fromAdoption(adoptionCareDto);
+                shelterDataCommandPort.saveShelter(shelter);
+            }
+        } catch (Exception e) {
+            log.error("보호소 정보 업데이트 중 오류 발생: careRegNo={}, error={}",
+                    careRegNo, e.getMessage(), e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
@@ -3,7 +3,7 @@ package kr.co.pawong.pwbe.shelter.application.service;
 import java.util.List;
 import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
 import kr.co.pawong.pwbe.shelter.application.port.in.UpdateShelterDataUseCase;
-import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.ShelterCreate;
 import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataCommandPort;
 import kr.co.pawong.pwbe.shelter.application.port.out.ShelterDataQueryPort;
 import kr.co.pawong.pwbe.shelter.application.service.support.ShelterMapper;

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/UpdateShelterDataService.java
@@ -20,7 +20,6 @@ public class UpdateShelterDataService implements UpdateShelterDataUseCase {
 
     private final ShelterDataQueryPort shelterDataQueryPort;
     private final ShelterDataCommandPort shelterDataCommandPort;
-    private final ShelterMapper shelterMapper;
 
     // ShelterCreate -> Shelter -> Repo에 전달
     @Override
@@ -37,20 +36,15 @@ public class UpdateShelterDataService implements UpdateShelterDataUseCase {
     @Transactional
     public void updateShelterIfNotExist(AdoptionCareDto adoptionCareDto) {
         String careRegNo = adoptionCareDto.getCareRegNo();
-        try {
-            // 보호소 번호로 기존 보호소 검색
-            boolean exists = shelterDataQueryPort.existsByCareRegNo(careRegNo);
+        // 보호소 번호로 기존 보호소 검색
+        boolean exists = shelterDataQueryPort.existsByCareRegNo(careRegNo);
 
-            // 보호소가 존재하지 않는 경우에만 새로 저장
-            if (!exists) {
-                // 매퍼를 사용하여 DTO를 도메인 객체로 변환
-                Shelter shelter = shelterMapper.fromAdoption(adoptionCareDto);
-                shelterDataCommandPort.saveShelter(shelter);
-            }
-        } catch (Exception e) {
-            log.error("보호소 정보 업데이트 중 오류 발생: careRegNo={}, error={}",
-                    careRegNo, e.getMessage(), e);
-            throw e;
+        // 보호소가 존재하지 않는 경우에만 새로 저장
+        if (!exists) {
+            // 매퍼를 사용하여 DTO를 도메인 객체로 변환
+            Shelter shelter = ShelterMapper.fromAdoption(adoptionCareDto);
+            shelterDataCommandPort.saveShelter(shelter);
         }
+
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/support/ShelterMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/support/ShelterMapper.java
@@ -1,0 +1,27 @@
+package kr.co.pawong.pwbe.shelter.application.service.support;
+
+import static kr.co.pawong.pwbe.global.util.ApiDataUtils.parseAddress;
+
+import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.shelter.domain.Shelter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShelterMapper {
+    public Shelter fromAdoption(AdoptionCareDto adoptionCareDto) {
+        // 주소 파싱
+        String[] addressParts = parseAddress(adoptionCareDto.getCareAddr());
+        String city = addressParts[0];
+        String district = addressParts[1];
+
+        return Shelter.builder()
+                .careRegNo(adoptionCareDto.getCareRegNo())
+                .careNm(adoptionCareDto.getCareNm())
+                .careTel(adoptionCareDto.getCareTel())
+                .careAddr(adoptionCareDto.getCareAddr())
+                .orgNm(adoptionCareDto.getOrgNm())
+                .city(city)          // 파싱된 도시 정보 추가
+                .district(district)  // 파싱된 지역구 정보 추가
+                .build();
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/shelter/application/service/support/ShelterMapper.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/application/service/support/ShelterMapper.java
@@ -2,13 +2,12 @@ package kr.co.pawong.pwbe.shelter.application.service.support;
 
 import static kr.co.pawong.pwbe.global.util.ApiDataUtils.parseAddress;
 
-import kr.co.pawong.pwbe.adoption.application.port.in.dto.AdoptionCareDto;
+import kr.co.pawong.pwbe.adoption.application.port.out.dto.AdoptionCareDto;
 import kr.co.pawong.pwbe.shelter.domain.Shelter;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ShelterMapper {
-    public Shelter fromAdoption(AdoptionCareDto adoptionCareDto) {
+
+    public static Shelter fromAdoption(AdoptionCareDto adoptionCareDto) {
         // 주소 파싱
         String[] addressParts = parseAddress(adoptionCareDto.getCareAddr());
         String city = addressParts[0];

--- a/src/main/java/kr/co/pawong/pwbe/shelter/domain/Shelter.java
+++ b/src/main/java/kr/co/pawong/pwbe/shelter/domain/Shelter.java
@@ -3,7 +3,7 @@ package kr.co.pawong.pwbe.shelter.domain;
 
 import java.time.LocalDate;
 
-import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterCreate;
+import kr.co.pawong.pwbe.infrastructure.api.dto.ShelterCreate;
 import kr.co.pawong.pwbe.shelter.application.port.in.dto.ShelterUpdate;
 import kr.co.pawong.pwbe.shelter.enums.DivisionNm;
 import lombok.Builder;


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#21 -> develop

### 변경 사항
1. shelter에 보호소 정보가 없다면 adoption에서 정보를 가져와 저장하는 로직 구현
- 최대한 성운님의 조언을 이해하고 고민하며,, 구현했는데 패키지 구조가 맞는지 확인 부탁드려요,,

2. ApiDataUtils 생성
- api 요청 후 데이터 전처리 시에 adoption과 shelter에서 공통으로 쓰는 함수가 많아 util로 뺐습니다.
- 시간 관련 함수는 TimeUtils에 넣었습니다!

3. ApiShelterService 환경변수 변경

4. imageUrl -> imageKey 변경으로 인한 오류 수정

5. adoption -> update 함수 예외처리 공통 예외처리 방법으로 수정

6. Shelter가 ApiShelterService로 되어있어 통합하고자 adoption에 ApiRequestUsecase, ApiRequestService -> ApiAdoptionUsecase, ApiAdoptionService로 변경하였습니다.

### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
s3 환경변수 오류 이슈로 실행이 안되서 해결하고 나면 테스트 결과 넣겠습니다! 전에 잘 돌아가는거 확인하고 커밋했습니다!
