### PR TITLE
[PW-47] /api 요청에서 csrf token 검사를 무시하도록 설정

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/user/config/SecurityConfig.java
+++ b/src/main/java/kr/co/pawong/pwbe/user/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/api/**")
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // JS에서 읽을 수 있도록 HttpOnly=false
                 )
 


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hotfix/#47 -> develop

### 변경 사항
websocket security 설정을 하면서 csrf token 검사를 진행하는데
api 요청시에도 해당 검사가 진행되면서 인증 에러가 났습니다.
그래서 /api 로 들어오는 요청은 csrf-token을 무시하도록 설정을 추가했습니다.

### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
- local로 클라이언트에서 북마크, 토글 요청시 정상 동작했습니다.
