### PR TITLE
[PW-72] 채팅메세지 DTO에 메세지 전송자의 프로필 이미지 정보 추가

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
@@ -30,11 +30,12 @@ public class ChatMessageEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onChatMessageCreated(ChatMessageCreatedEvent event) {
         ChatMessage chatMessage = event.getChatMessage();
+        User sender = userDataQueryPort.findByUserIdOrThrow(event.getChatMessage().getSenderId());
         ChatMessageDetail messageDetail = ChatMessageDetail
                 .from(chatMessage)
-                .updateSenderName(
-                        userDataQueryPort.findByUserIdOrThrow(event.getChatMessage().getSenderId())
-                        .getNickname());
+                .updateSenderInfo(
+                        sender.getNickname(),
+                        sender.getProfileImage());
 
         /* find user in chat room */
         ChatRoom chatRoom = chatRoomDataQueryPort.findChatRoomByIdOrThrow(chatMessage.getChatRoomId());

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/dto/ChatMessageDetail.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/dto/ChatMessageDetail.java
@@ -19,12 +19,13 @@ public class ChatMessageDetail {
     private String content;     // 메시지 내용
     private Long senderId;      // 누가 보냈는지 (활용가능)
     private String senderName;
+    private String senderProfileImage;
     private ChatMessageStatus status;   // 읽음 여부 (언제 읽었는지는 일단 활용X)
     @JsonSerialize(using = ToStringSerializer.class)
     private Long createdAt; // Instant -> Long (에폭크 타임) -> String -> JSON
 
     public static ChatMessageDetail from(ChatMessage chatMessage) {
-        return ChatMessageDetail.builder()
+        return kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail.builder()
                 .chatMessageId(chatMessage.getMessageId())
                 .content(chatMessage.getContent())
                 .senderId(chatMessage.getSenderId())
@@ -33,8 +34,9 @@ public class ChatMessageDetail {
                 .build();
     }
 
-    public ChatMessageDetail updateSenderName(String userNickName) {
+    public ChatMessageDetail updateSenderInfo(String userNickName, String userProfileImage) {
         this.senderName = userNickName;
+        this.senderProfileImage = userProfileImage;
         return this;
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
@@ -10,6 +10,7 @@ import kr.co.pawong.pwbe.chat.domain.ChatMessage;
 import kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode;
 import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.user.application.port.out.UserDataQueryPort;
+import kr.co.pawong.pwbe.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,9 +33,12 @@ public class QueryChatMessageDataService implements QueryChatMessageDataUseCase 
                 .findChatMessagesByChatRoomIdInLatestOrder(chatRoomId);
 
         return chatMessages.stream()
-                .map(msg -> ChatMessageDetail
-                                .from(msg)
-                                .updateSenderName(userDataQueryPort.findByUserIdOrThrow(msg.getSenderId()).getNickname())
+                .map(msg -> {
+                    User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
+                    return ChatMessageDetail
+                                    .from(msg)
+                                    .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
+                    }
                 )
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#72 -> develop

### 변경 사항
채팅방 메세지 DTO를 전달할 때에 전송자의 프로필 이미지가 없어서 클라이언트에서 모두 디폴트 이미지로 보여지는 이슈
-> 채팅방 메세지 DTO에 전송자 프로필 이미지 추가

### PR 체크리스트
- [ ] 테스트는 모두 통과했나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
