### PR TITLE
[PW-80] 채팅 메세지 전송하면 FCM 알림 전송

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/broker/SimpleBrokerChatMessageAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/broker/SimpleBrokerChatMessageAdapter.java
@@ -1,8 +1,11 @@
 package kr.co.pawong.pwbe.chat.adapter.out.broker;
 
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageBrokerPort;
+import kr.co.pawong.pwbe.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -10,9 +13,25 @@ import org.springframework.stereotype.Component;
 public class SimpleBrokerChatMessageAdapter implements ChatMessageBrokerPort {
 
     private final SimpMessagingTemplate template;
+    private final SimpUserRegistry simpUserRegistry;
 
     @Override
     public void sendMessageToUser(String username, String destination, Object object) {
         template.convertAndSendToUser(username, destination, object);
+    }
+
+    @Override
+    public boolean isUserSubscribedToRoom(User receiver, Long roomId) {
+        Long socialId = receiver.getSocialId();
+        SimpUser simpUser = simpUserRegistry.getUser(String.valueOf(socialId));
+        if (simpUser == null) {
+            return false;
+        }
+        String expectDestination = "/user/queue/chat/" + roomId;
+        return simpUser.getSessions()
+                .stream()
+                .flatMap(session -> session.getSubscriptions().stream())
+                .anyMatch(sub -> expectDestination.equals(sub.getDestination()));
+
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/notification/ChatNotificationAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/notification/ChatNotificationAdapter.java
@@ -1,0 +1,19 @@
+package kr.co.pawong.pwbe.chat.adapter.out.notification;
+
+import kr.co.pawong.pwbe.notification.application.port.in.NotificationUseCase;
+import kr.co.pawong.pwbe.notification.application.port.in.dto.NotificationRequest;
+import kr.co.pawong.pwbe.notification.application.port.out.ChatNotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatNotificationAdapter implements ChatNotificationPort {
+
+    private final NotificationUseCase notificationUseCase;
+
+    @Override
+    public void sendChatFcmNotification(NotificationRequest notificationRequest) {
+        notificationUseCase.sendChatNotification(notificationRequest);
+    }
+}

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
@@ -37,15 +37,10 @@ public class ChatMessageEventListener {
                         sender.getNickname(),
                         sender.getProfileImage());
 
-        /* find user in chat room */
-        ChatRoom chatRoom = chatRoomDataQueryPort.findChatRoomByIdOrThrow(chatMessage.getChatRoomId());
-        User author = userDataQueryPort.findByUserIdOrThrow(chatRoom.getAuthorId());
-        User participant = userDataQueryPort.findByUserIdOrThrow(chatRoom.getParticipantId());
-
         /* send it to users */
         String userDest = "/queue/chat/" + chatMessage.getChatRoomId();
-        chatMessageBrokerPort.sendMessageToUser(String.valueOf(author.getSocialId()), userDest, messageDetail);
-        chatMessageBrokerPort.sendMessageToUser(String.valueOf(participant.getSocialId()), userDest,messageDetail);
+        chatMessageBrokerPort.sendMessageToUser(String.valueOf(event.getAuthor().getSocialId()), userDest, messageDetail);
+        chatMessageBrokerPort.sendMessageToUser(String.valueOf(event.getParticipant().getSocialId()), userDest,messageDetail);
     }
 
     @Async("chatExecutor")

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
@@ -35,7 +35,7 @@ public class ChatMessageEventListener {
     private final ChatMessageBrokerPort chatMessageBrokerPort;
     private final ApplicationEventPublisher publisher;
 
-    @Async("chatExecutor")   // 별도 스레드풀에서 실행
+    @Async("chatExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onChatMessageCreated(ChatMessageCreatedEvent event) {
 

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatMessageEventListener.java
@@ -1,23 +1,31 @@
 package kr.co.pawong.pwbe.chat.application.listener;
 
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.*;
+
 import java.util.Map;
 import java.util.Objects;
 import kr.co.pawong.pwbe.chat.application.listener.event.ChatMessageCreatedEvent;
 import kr.co.pawong.pwbe.chat.application.listener.event.ChatMessageReadEvent;
+import kr.co.pawong.pwbe.chat.application.listener.event.ChatNotificationEvent;
 import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageBrokerPort;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatRoomDataQueryPort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
 import kr.co.pawong.pwbe.chat.domain.ChatRoom;
+import kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode;
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.user.application.port.out.UserDataQueryPort;
 import kr.co.pawong.pwbe.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatMessageEventListener {
@@ -25,22 +33,37 @@ public class ChatMessageEventListener {
     private final ChatRoomDataQueryPort chatRoomDataQueryPort;
     private final UserDataQueryPort userDataQueryPort;
     private final ChatMessageBrokerPort chatMessageBrokerPort;
+    private final ApplicationEventPublisher publisher;
 
     @Async("chatExecutor")   // 별도 스레드풀에서 실행
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onChatMessageCreated(ChatMessageCreatedEvent event) {
-        ChatMessage chatMessage = event.getChatMessage();
-        User sender = userDataQueryPort.findByUserIdOrThrow(event.getChatMessage().getSenderId());
-        ChatMessageDetail messageDetail = ChatMessageDetail
-                .from(chatMessage)
-                .updateSenderInfo(
-                        sender.getNickname(),
-                        sender.getProfileImage());
 
-        /* send it to users */
-        String userDest = "/queue/chat/" + chatMessage.getChatRoomId();
-        chatMessageBrokerPort.sendMessageToUser(String.valueOf(event.getAuthor().getSocialId()), userDest, messageDetail);
-        chatMessageBrokerPort.sendMessageToUser(String.valueOf(event.getParticipant().getSocialId()), userDest,messageDetail);
+        try {
+            ChatMessage chatMessage = event.getChatMessage();
+            User sender = userDataQueryPort.findByUserIdOrThrow(
+                    event.getChatMessage().getSenderId());
+            ChatMessageDetail messageDetail = ChatMessageDetail
+                    .from(chatMessage)
+                    .updateSenderInfo(
+                            sender.getNickname(),
+                            sender.getProfileImage());
+
+            /* send it to users */
+            String userDest = "/queue/chat/" + chatMessage.getChatRoomId();
+            chatMessageBrokerPort.sendMessageToUser(String.valueOf(event.getAuthor().getSocialId()),
+                    userDest, messageDetail);
+            chatMessageBrokerPort.sendMessageToUser(
+                    String.valueOf(event.getParticipant().getSocialId()), userDest, messageDetail);
+
+            /* send notification */
+            User receiver = (event.getAuthor().getUserId().equals(chatMessage.getSenderId())) ? event.getParticipant() : event.getAuthor();
+            publisher.publishEvent(new ChatNotificationEvent(receiver, chatMessage));
+
+        } catch (Exception exception) {
+            log.info(exception.getMessage());
+            throw new BaseException(BROKER_FAIL);
+        }
     }
 
     @Async("chatExecutor")
@@ -57,4 +80,5 @@ public class ChatMessageEventListener {
         chatMessageBrokerPort.sendMessageToUser(String.valueOf(recipient.getSocialId()), userDest, Map.of("readerId", event.getReaderId(), "lastReadMessageId", event.getLastReadMessageId())
         );
     }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatNotificationListener.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatNotificationListener.java
@@ -19,7 +19,7 @@ public class ChatNotificationListener {
     private final ChatMessageBrokerPort chatMessageBrokerPort;
     private final ChatNotificationPort chatNotificationPort;
 
-    @Async("notificationExecutor")   // 별도 스레드풀에서 실행
+    @Async("notificationExecutor")
     @EventListener
     public void onChatMessageCreated(ChatNotificationEvent event) {
 

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatNotificationListener.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/ChatNotificationListener.java
@@ -1,0 +1,44 @@
+package kr.co.pawong.pwbe.chat.application.listener;
+
+import kr.co.pawong.pwbe.chat.application.listener.event.ChatNotificationEvent;
+import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageBrokerPort;
+import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+import kr.co.pawong.pwbe.lostPost.enums.PostType;
+import kr.co.pawong.pwbe.notification.application.port.in.dto.NotificationRequest;
+import kr.co.pawong.pwbe.notification.application.port.out.ChatNotificationPort;
+import kr.co.pawong.pwbe.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatNotificationListener {
+
+    private final ChatMessageBrokerPort chatMessageBrokerPort;
+    private final ChatNotificationPort chatNotificationPort;
+
+    @Async("notificationExecutor")   // 별도 스레드풀에서 실행
+    @EventListener
+    public void onChatMessageCreated(ChatNotificationEvent event) {
+
+        /* Send notification */
+        sendChatNotificationToSessionUser(event.getReceiver(), event.getChatMessage());
+
+    }
+
+    private void sendChatNotificationToSessionUser(User receiver, ChatMessage chatMessage) {
+        if (chatMessageBrokerPort.isUserSubscribedToRoom(receiver, chatMessage.getChatRoomId())) {
+            return;
+        }
+
+        chatNotificationPort.sendChatFcmNotification(new NotificationRequest(
+                receiver.getUserId(),
+                chatMessage.getContent(),
+                chatMessage.getChatRoomId(),
+                PostType.LOST
+        ));
+    }
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/event/ChatMessageCreatedEvent.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/event/ChatMessageCreatedEvent.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.chat.application.listener.event;
 
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+import kr.co.pawong.pwbe.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,4 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ChatMessageCreatedEvent {
     private final ChatMessage chatMessage;
+    private final User author;
+    private final User participant;
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/listener/event/ChatNotificationEvent.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/listener/event/ChatNotificationEvent.java
@@ -1,0 +1,13 @@
+package kr.co.pawong.pwbe.chat.application.listener.event;
+
+import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+import kr.co.pawong.pwbe.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatNotificationEvent {
+    User receiver;
+    ChatMessage chatMessage;
+}

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageBrokerPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageBrokerPort.java
@@ -1,5 +1,9 @@
 package kr.co.pawong.pwbe.chat.application.port.out;
 
+import kr.co.pawong.pwbe.user.domain.User;
+
 public interface ChatMessageBrokerPort {
     void sendMessageToUser(String username, String destination, Object object);
+    boolean isUserSubscribedToRoom(User receiver, Long roomId);
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
@@ -1,16 +1,17 @@
 package kr.co.pawong.pwbe.chat.application.service;
 
 import kr.co.pawong.pwbe.chat.adapter.in.messaging.dto.request.ChatMessageCreateRequest;
+import kr.co.pawong.pwbe.chat.adapter.out.notification.ChatNotificationAdapter;
 import kr.co.pawong.pwbe.chat.application.listener.event.ChatMessageCreatedEvent;
 import kr.co.pawong.pwbe.chat.application.listener.event.ChatMessageReadEvent;
 import kr.co.pawong.pwbe.chat.application.port.in.CommandChatMessageDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.SendChatMessageBrokerUseCase;
+import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageBrokerPort;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageDataQueryPort;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatRoomDataQueryPort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
 import kr.co.pawong.pwbe.chat.domain.ChatRoom;
 import kr.co.pawong.pwbe.lostPost.enums.PostType;
-import kr.co.pawong.pwbe.notification.application.port.in.NotificationUseCase;
 import kr.co.pawong.pwbe.notification.application.port.in.dto.NotificationRequest;
 import kr.co.pawong.pwbe.user.application.port.out.UserDataQueryPort;
 import kr.co.pawong.pwbe.user.domain.User;
@@ -26,9 +27,10 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
     private final CommandChatMessageDataUseCase commandChatMessageDataUseCase;
     private final ChatMessageDataQueryPort chatMessageDataQueryPort;
     private final ChatRoomDataQueryPort chatRoomDataQueryPort;
-    private final NotificationUseCase notificationUseCase;
+    private final ChatNotificationAdapter chatNotificationAdapter;
     private final UserDataQueryPort userDataQueryPort;
     private final ApplicationEventPublisher publisher;
+    private final ChatMessageBrokerPort chatMessageBrokerPort;
 
     @Override
     @Transactional
@@ -40,27 +42,37 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
         ChatRoom chatRoom = chatRoomDataQueryPort.findChatRoomByIdOrThrow(chatMessage.getChatRoomId());
         User author = userDataQueryPort.findByUserIdOrThrow(chatRoom.getAuthorId());
         User participant = userDataQueryPort.findByUserIdOrThrow(chatRoom.getParticipantId());
-        User receiver = (author.getUserId().equals(chatMessage.getSenderId()))? participant: author;
+        User receiver = (author.getUserId().equals(chatMessage.getSenderId())) ? participant : author;
 
         /* Send a chat message */
         publisher.publishEvent(new ChatMessageCreatedEvent(chatMessage, author, participant));
 
         /* Send notification */
-        notificationUseCase.sendChatNotification(new NotificationRequest(
+        sendChatNotificationToSessionUser(receiver, chatMessage);
+
+    }
+
+    private void sendChatNotificationToSessionUser(User receiver, ChatMessage chatMessage) {
+        if (!chatMessageBrokerPort.isUserSubscribedToRoom(receiver, chatMessage.getChatRoomId())) {
+            return;
+        }
+
+        chatNotificationAdapter.sendChatFcmNotification(new NotificationRequest(
                 receiver.getUserId(),
                 chatMessage.getContent(),
                 chatMessage.getChatRoomId(),
                 PostType.LOST
         ));
-
     }
 
     @Override
     @Transactional
     public void readMessage(Long roomId, Long userId) {
         commandChatMessageDataUseCase.markAllAsRead(roomId, userId);
-        ChatMessage chatMessage = chatMessageDataQueryPort.findLatestReadMessageOrThrow(roomId, userId);
-        publisher.publishEvent(new ChatMessageReadEvent(roomId, userId, chatMessage.getMessageId()));
+        ChatMessage chatMessage = chatMessageDataQueryPort.findLatestReadMessageOrThrow(roomId,
+                userId);
+        publisher.publishEvent(
+                new ChatMessageReadEvent(roomId, userId, chatMessage.getMessageId()));
     }
 
     private ChatMessage createChatMessage(ChatMessageCreateRequest request, Long chatRoomId,

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
@@ -6,7 +6,14 @@ import kr.co.pawong.pwbe.chat.application.listener.event.ChatMessageReadEvent;
 import kr.co.pawong.pwbe.chat.application.port.in.CommandChatMessageDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.SendChatMessageBrokerUseCase;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageDataQueryPort;
+import kr.co.pawong.pwbe.chat.application.port.out.ChatRoomDataQueryPort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+import kr.co.pawong.pwbe.chat.domain.ChatRoom;
+import kr.co.pawong.pwbe.lostPost.enums.PostType;
+import kr.co.pawong.pwbe.notification.application.port.in.NotificationUseCase;
+import kr.co.pawong.pwbe.notification.application.port.in.dto.NotificationRequest;
+import kr.co.pawong.pwbe.user.application.port.out.UserDataQueryPort;
+import kr.co.pawong.pwbe.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -18,6 +25,9 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
 
     private final CommandChatMessageDataUseCase commandChatMessageDataUseCase;
     private final ChatMessageDataQueryPort chatMessageDataQueryPort;
+    private final ChatRoomDataQueryPort chatRoomDataQueryPort;
+    private final NotificationUseCase notificationUseCase;
+    private final UserDataQueryPort userDataQueryPort;
     private final ApplicationEventPublisher publisher;
 
     @Override
@@ -25,7 +35,24 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
     public void createAndSendChatMessage(ChatMessageCreateRequest request, Long chatRoomId,
             Long userId) {
         ChatMessage chatMessage = createChatMessage(request, chatRoomId, userId);
-        publisher.publishEvent(new ChatMessageCreatedEvent(chatMessage));
+
+        /* find user in chat room */
+        ChatRoom chatRoom = chatRoomDataQueryPort.findChatRoomByIdOrThrow(chatMessage.getChatRoomId());
+        User author = userDataQueryPort.findByUserIdOrThrow(chatRoom.getAuthorId());
+        User participant = userDataQueryPort.findByUserIdOrThrow(chatRoom.getParticipantId());
+        User receiver = (author.getUserId().equals(chatMessage.getSenderId()))? participant: author;
+
+        /* Send a chat message */
+        publisher.publishEvent(new ChatMessageCreatedEvent(chatMessage, author, participant));
+
+        /* Send notification */
+        notificationUseCase.sendChatNotification(new NotificationRequest(
+                receiver.getUserId(),
+                chatMessage.getContent(),
+                chatMessage.getChatRoomId(),
+                PostType.LOST
+        ));
+
     }
 
     @Override

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
@@ -27,42 +27,24 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
     private final CommandChatMessageDataUseCase commandChatMessageDataUseCase;
     private final ChatMessageDataQueryPort chatMessageDataQueryPort;
     private final ChatRoomDataQueryPort chatRoomDataQueryPort;
-    private final ChatNotificationAdapter chatNotificationAdapter;
     private final UserDataQueryPort userDataQueryPort;
     private final ApplicationEventPublisher publisher;
-    private final ChatMessageBrokerPort chatMessageBrokerPort;
 
     @Override
     @Transactional
     public void createAndSendChatMessage(ChatMessageCreateRequest request, Long chatRoomId,
             Long userId) {
+        /* save to db */
         ChatMessage chatMessage = createChatMessage(request, chatRoomId, userId);
 
         /* find user in chat room */
         ChatRoom chatRoom = chatRoomDataQueryPort.findChatRoomByIdOrThrow(chatMessage.getChatRoomId());
         User author = userDataQueryPort.findByUserIdOrThrow(chatRoom.getAuthorId());
         User participant = userDataQueryPort.findByUserIdOrThrow(chatRoom.getParticipantId());
-        User receiver = (author.getUserId().equals(chatMessage.getSenderId())) ? participant : author;
+
 
         /* Send a chat message */
         publisher.publishEvent(new ChatMessageCreatedEvent(chatMessage, author, participant));
-
-        /* Send notification */
-        sendChatNotificationToSessionUser(receiver, chatMessage);
-
-    }
-
-    private void sendChatNotificationToSessionUser(User receiver, ChatMessage chatMessage) {
-        if (!chatMessageBrokerPort.isUserSubscribedToRoom(receiver, chatMessage.getChatRoomId())) {
-            return;
-        }
-
-        chatNotificationAdapter.sendChatFcmNotification(new NotificationRequest(
-                receiver.getUserId(),
-                chatMessage.getContent(),
-                chatMessage.getChatRoomId(),
-                PostType.LOST
-        ));
     }
 
     @Override

--- a/src/main/java/kr/co/pawong/pwbe/global/config/ExecutorConfig.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/config/ExecutorConfig.java
@@ -34,4 +34,15 @@ public class ExecutorConfig {
         return executor;
     }
 
+    @Bean(name = "notificationExecutor")
+    public ThreadPoolTaskExecutor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);       // 최소 10개 스레드
+        executor.setMaxPoolSize(10);        // 최대 10개 스레드
+        executor.setQueueCapacity(1000);   // 대기 큐 크기
+        executor.setThreadNamePrefix("notify-exec-");
+        executor.initialize();
+        return executor;
+    }
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
@@ -78,6 +78,8 @@ public enum CustomErrorCode implements ErrorCode {
     NOTIFICATION_ADOPTION_SEND_ERROR(INTERNAL_SERVER_ERROR, "유사 공고 알림 발송에 실패하였습니다."),
     EMAIL_SEND_FAIL(INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다."),
     REDIS_SAVE_ERROR(INTERNAL_SERVER_ERROR,"REDIS 저장에 실패하였습니다."),
+    BROKER_FAIL(INTERNAL_SERVER_ERROR, "브로커 전송이 실패하였습니다."),
+
     // 검색
     SEARCH_ERROR(SERVICE_UNAVAILABLE, "검색 기능이 정상적으로 동작하지 않습니다."),
 

--- a/src/main/java/kr/co/pawong/pwbe/notification/application/port/out/ChatNotificationPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/notification/application/port/out/ChatNotificationPort.java
@@ -1,0 +1,9 @@
+package kr.co.pawong.pwbe.notification.application.port.out;
+
+import kr.co.pawong.pwbe.notification.application.port.in.dto.NotificationRequest;
+
+public interface ChatNotificationPort {
+
+    void sendChatFcmNotification(NotificationRequest notificationRequest);
+
+}


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#80 -> develop

### 변경 사항
1. 채팅 메세지 전송 시 FCM 알림 전송
2. 해당 채팅방에 세션 유지 중인 유저에게는 전송하지 않음
3. DB저장 -> 브로커 전송 비동기 순서 보장, 브로커 전송 완료 이후 알림 전송

### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과

