### PR TITLE
[PW-89] 최근 N건 채팅 메세지 캐싱후 조회 로직

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/ChatMessageQueryController.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/ChatMessageQueryController.java
@@ -2,8 +2,6 @@ package kr.co.pawong.pwbe.chat.adapter.in.api;
 
 import java.util.List;
 import kr.co.pawong.pwbe.chat.adapter.in.api.dto.response.ChatMessagesResponse;
-import kr.co.pawong.pwbe.chat.application.port.in.CommandChatMessageDataUseCase;
-import kr.co.pawong.pwbe.chat.application.port.in.CommandChatRoomDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.QueryChatMessageDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
 import kr.co.pawong.pwbe.global.security.dto.CustomUserDetails;
@@ -14,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,10 +42,28 @@ public class ChatMessageQueryController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();
-        List<ChatMessageDetail> lastestMessages = queryChatMessageDataUseCase.findLastestMessagesInChatRoom(userId, roomId);
+        List<ChatMessageDetail> lastestMessages = queryChatMessageDataUseCase.findLatestMessagesInChatRoom(userId, roomId, null);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ChatMessagesResponse(lastestMessages));
+    }
+
+    /**
+     * 2) 과거 페이지 가져오기
+     * → before 파라미터(“밀리초”)를 넘기면, before보다 이전 메시지 N건만 가져옴
+     */
+    @GetMapping("/rooms/{roomId}/messages/before")
+    public ResponseEntity<ChatMessagesResponse> findMessagesBeforeInChatRoom(
+            @PathVariable Long roomId,
+            @RequestParam("before") Long beforeMillis,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        List<ChatMessageDetail> olderPage =
+                queryChatMessageDataUseCase.findLatestMessagesInChatRoom(userId, roomId, beforeMillis);
+
+        return ResponseEntity.ok(new ChatMessagesResponse(olderPage));
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/ChatMessageQueryController.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/ChatMessageQueryController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatMessageQueryController {
 
     private final QueryChatMessageDataUseCase queryChatMessageDataUseCase;
+
     @GetMapping("/rooms/{roomId}/messages")
     public ResponseEntity<ChatMessagesResponse> findAllMessagesInChatRoom(
             @PathVariable Long roomId,
@@ -34,5 +35,18 @@ public class ChatMessageQueryController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ChatMessagesResponse(allMessages));
+    }
+
+    @GetMapping("/rooms/{roomId}/messages/lastest")
+    public ResponseEntity<ChatMessagesResponse> findLastestMessagesInChatRoom(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        List<ChatMessageDetail> lastestMessages = queryChatMessageDataUseCase.findLastestMessagesInChatRoom(userId, roomId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ChatMessagesResponse(lastestMessages));
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/ChatMessageQueryController.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/ChatMessageQueryController.java
@@ -2,17 +2,20 @@ package kr.co.pawong.pwbe.chat.adapter.in.api;
 
 import java.util.List;
 import kr.co.pawong.pwbe.chat.adapter.in.api.dto.response.ChatMessagesResponse;
+import kr.co.pawong.pwbe.chat.adapter.in.api.dto.response.SliceChatMessagePageResponse;
 import kr.co.pawong.pwbe.chat.application.port.in.QueryChatMessageDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
 import kr.co.pawong.pwbe.global.security.dto.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,34 +39,16 @@ public class ChatMessageQueryController {
                 .body(new ChatMessagesResponse(allMessages));
     }
 
-    @GetMapping("/rooms/{roomId}/messages/lastest")
-    public ResponseEntity<ChatMessagesResponse> findLastestMessagesInChatRoom(
+    @GetMapping("/rooms/{roomId}/messages/slice")
+    public ResponseEntity<SliceChatMessagePageResponse> getOlderMessage(
             @PathVariable Long roomId,
+            @PageableDefault(page = 0, size = 50, sort = "messageId", direction = Direction.ASC) Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long userId = userDetails.getUserId();
-        List<ChatMessageDetail> lastestMessages = queryChatMessageDataUseCase.findLatestMessagesInChatRoom(userId, roomId, null);
-
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(new ChatMessagesResponse(lastestMessages));
+        SliceChatMessagePageResponse sliceChatMessagePageResponse =
+                queryChatMessageDataUseCase.getSliceMessage(userDetails.getUserId(),roomId, pageable);
+        return ResponseEntity.ok(sliceChatMessagePageResponse);
     }
 
-    /**
-     * 2) 과거 페이지 가져오기
-     * → before 파라미터(“밀리초”)를 넘기면, before보다 이전 메시지 N건만 가져옴
-     */
-    @GetMapping("/rooms/{roomId}/messages/before")
-    public ResponseEntity<ChatMessagesResponse> findMessagesBeforeInChatRoom(
-            @PathVariable Long roomId,
-            @RequestParam("before") Long beforeMillis,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        Long userId = userDetails.getUserId();
 
-        List<ChatMessageDetail> olderPage =
-                queryChatMessageDataUseCase.findLatestMessagesInChatRoom(userId, roomId, beforeMillis);
-
-        return ResponseEntity.ok(new ChatMessagesResponse(olderPage));
-    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/dto/response/SliceChatMessagePageResponse.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/in/api/dto/response/SliceChatMessagePageResponse.java
@@ -1,0 +1,16 @@
+package kr.co.pawong.pwbe.chat.adapter.in.api.dto.response;
+
+import java.util.List;
+import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SliceChatMessagePageResponse {
+    private List<ChatMessageDetail> messages;
+    private boolean hasNext;
+    private int page;
+    private int size;
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/cache/redis/RedisChatMessageAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/cache/redis/RedisChatMessageAdapter.java
@@ -5,6 +5,7 @@ import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.CHATMESSA
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageCachePort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
@@ -20,57 +21,110 @@ import org.springframework.stereotype.Component;
 public class RedisChatMessageAdapter implements ChatMessageCachePort {
 
     private static final int MAX_CACHE_SIZE = 50;
-
+    private static final String CHAT_ROOM_PREFIX = "chat:room:";
+    private static final String MESSAGE_SUFFIX = ":messages";
+    private static final String TOTAL_COUNT_SUFFIX = ":total:count";
 
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
 
     /**
      * Redis에 채팅 메시지를 저장하고, 최대 n개만 보관되도록 trim 처리한다.
+     *
      * @param chatRoomId  캐시할 채팅방 ID
      * @param chatMessage 저장할 ChatMessageDto 객체
-     * @param maxSize     최대 보관할 메시지 개수 (N)
      */
     @Override
-    public void cacheMessage(Long chatRoomId, ChatMessage chatMessage, int maxSize) {
-        String key = getRedisKey(chatRoomId);
+    public void cacheMessage(Long chatRoomId, ChatMessage chatMessage) {
+        String key = getRedisKey(CHAT_ROOM_PREFIX + chatRoomId, MESSAGE_SUFFIX);
         String json = convertToJson(chatMessage);
 
-        redisTemplate.opsForList().rightPush(key, json);
-        // 리스트 길이를 최근 maxSize건만 남기도록 조정
-        // trim(start, end): 인덱스 기준. -maxSize ~ -1 이면 뒤에서 maxSize건
-        redisTemplate.opsForList().trim(key, -maxSize, -1);
+        redisTemplate.opsForList().leftPush(key, json);
+        redisTemplate.opsForList().trim(key, 0, MAX_CACHE_SIZE - 1);
+        countMessages(chatRoomId);
+    }
+
+    /**
+     * Redis에 채팅 메시지 리스트를 저장하고, 최대 n개만 보관되도록 trim 처리한다.
+     *
+     * @param chatMessageList
+     * @param chatRoomId
+     */
+    @Override
+    public void cacheMessageChunk(List<ChatMessage> chatMessageList, Long chatRoomId) {
+        String key = getRedisKey(CHAT_ROOM_PREFIX + chatRoomId, MESSAGE_SUFFIX);
+        List<String> jsonList = chatMessageList.stream().map(this::convertToJson).toList();
+
+        for (String json : jsonList) {
+            redisTemplate.opsForList().leftPush(key, json);
+            countMessages(chatRoomId);
+        }
+        redisTemplate.opsForList().trim(key, 0, MAX_CACHE_SIZE - 1);
     }
 
     /**
      * Redis에서 해당 채팅룸의 최신 N건 메시지를 조회하여 DTO 리스트로 반환한다.
      *
-     * @param chatRoomId  조회할 채팅방 ID
-     * @param maxSize     가져올 최신 메시지 개수
+     * @param chatRoomId 조회할 채팅방 ID
      * @return 최신 N건의 ChatMessage 리스트 (없으면 빈 리스트)
      */
-    public List<ChatMessage> getLatestMessages(Long chatRoomId, int maxSize) {
-        String key = getRedisKey(chatRoomId);
-        List<String> messageList = redisTemplate.opsForList().range(key, -maxSize, -1);
+    public List<ChatMessage> getLatestMessages(Long chatRoomId) {
+        String key = getRedisKey(CHAT_ROOM_PREFIX + chatRoomId, MESSAGE_SUFFIX);
+        List<String> messageList = redisTemplate.opsForList().range(key, 0, MAX_CACHE_SIZE -1);
 
         if (messageList == null || messageList.isEmpty()) {
             return new ArrayList<>();
         }
 
+        Collections.reverse(messageList);
         return messageList.stream()
                 .map(this::convertFromJson)
                 .toList();
     }
 
+
+    @Override
+    public Long getTotalCount(Long roomId) {
+        String key = getRedisKey(CHAT_ROOM_PREFIX + roomId, TOTAL_COUNT_SUFFIX);
+        String count = redisTemplate.opsForValue().get(key);
+        if (count == null)  return 0L;
+
+        try {
+            return Long.parseLong(count);
+        } catch (NumberFormatException exception) {
+            return 0L;
+        }
+    }
+
+    @Override
+    public void updateTotalCount(Long chatRoomId, Long count) {
+        String countKey = getRedisKey(CHAT_ROOM_PREFIX + chatRoomId, TOTAL_COUNT_SUFFIX);
+
+        redisTemplate.opsForValue().set(countKey, String.valueOf(count));
+    }
+
+
     /**
-     * 채팅룸별 Redis 키 패턴
+     * 채팅방에 메시지가 하나 저장될 때마다 Redis에 저장된 totalCount를 1 증가시킨다.
+     *
+     * @param chatRoomId
      */
-    private String getRedisKey(Long chatRoomId) {
-        return "chat:room:" + chatRoomId + ":messages";
+    private void countMessages(Long chatRoomId) {
+        String countKey = getRedisKey(CHAT_ROOM_PREFIX + chatRoomId, TOTAL_COUNT_SUFFIX);
+        redisTemplate.opsForValue().increment(countKey, 1);
+    }
+
+
+    /**
+     * Redis 키 패턴
+     */
+    private String getRedisKey(String prefix, String suffix) {
+        return prefix + suffix;
     }
 
     /**
      * ChatMessage를 Json으로 변환합니다.
+     *
      * @param chatMessage
      * @return json String
      */
@@ -85,6 +139,7 @@ public class RedisChatMessageAdapter implements ChatMessageCachePort {
 
     /**
      * Json을 ChatMessage으로 변환합니다.
+     *
      * @param json
      * @return ChatMessage
      */

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/cache/redis/RedisChatMessageAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/cache/redis/RedisChatMessageAdapter.java
@@ -1,0 +1,100 @@
+package kr.co.pawong.pwbe.chat.adapter.out.cache.redis;
+
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.CHATMESSAGE_NOT_FOUND;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageCachePort;
+import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisChatMessageAdapter implements ChatMessageCachePort {
+
+    private static final int MAX_CACHE_SIZE = 50;
+
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Redis에 채팅 메시지를 저장하고, 최대 n개만 보관되도록 trim 처리한다.
+     * @param chatRoomId  캐시할 채팅방 ID
+     * @param chatMessage 저장할 ChatMessageDto 객체
+     * @param maxSize     최대 보관할 메시지 개수 (N)
+     */
+    @Override
+    public void cacheMessage(Long chatRoomId, ChatMessage chatMessage, int maxSize) {
+        String key = getRedisKey(chatRoomId);
+        String json = convertToJson(chatMessage);
+
+        redisTemplate.opsForList().rightPush(key, json);
+        // 리스트 길이를 최근 maxSize건만 남기도록 조정
+        // trim(start, end): 인덱스 기준. -maxSize ~ -1 이면 뒤에서 maxSize건
+        redisTemplate.opsForList().trim(key, -maxSize, -1);
+    }
+
+    /**
+     * Redis에서 해당 채팅룸의 최신 N건 메시지를 조회하여 DTO 리스트로 반환한다.
+     *
+     * @param chatRoomId  조회할 채팅방 ID
+     * @param maxSize     가져올 최신 메시지 개수
+     * @return 최신 N건의 ChatMessage 리스트 (없으면 빈 리스트)
+     */
+    public List<ChatMessage> getLatestMessages(Long chatRoomId, int maxSize) {
+        String key = getRedisKey(chatRoomId);
+        List<String> messageList = redisTemplate.opsForList().range(key, -maxSize, -1);
+
+        if (messageList == null || messageList.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return messageList.stream()
+                .map(this::convertFromJson)
+                .toList();
+    }
+
+    /**
+     * 채팅룸별 Redis 키 패턴
+     */
+    private String getRedisKey(Long chatRoomId) {
+        return "chat:room:" + chatRoomId + ":messages";
+    }
+
+    /**
+     * ChatMessage를 Json으로 변환합니다.
+     * @param chatMessage
+     * @return json String
+     */
+    private String convertToJson(ChatMessage chatMessage) {
+        try {
+            return objectMapper.writeValueAsString(chatMessage);
+        } catch (JsonProcessingException e) {
+            throw new BaseException(CHATMESSAGE_NOT_FOUND);
+//            log.error("Redis 캐시에 메시지 저장 실패: chatRoomId={}, error={}", chatMessage.getChatRoomId(), e.getMessage());
+        }
+    }
+
+    /**
+     * Json을 ChatMessage으로 변환합니다.
+     * @param json
+     * @return ChatMessage
+     */
+    private ChatMessage convertFromJson(String json) {
+        try {
+            return objectMapper.readValue(json, ChatMessage.class);
+        } catch (JsonProcessingException e) {
+            throw new BaseException(CHATMESSAGE_NOT_FOUND);
+        }
+    }
+
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/JpaChatMessageDataQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/JpaChatMessageDataQueryAdapter.java
@@ -1,6 +1,7 @@
 package kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa;
 
-import java.time.Instant;
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.*;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa.entity.ChatMessageEntity;
@@ -11,7 +12,8 @@ import kr.co.pawong.pwbe.chat.enums.ChatMessageStatus;
 import kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode;
 import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -35,39 +37,30 @@ public class JpaChatMessageDataQueryAdapter implements ChatMessageDataQueryPort 
     public ChatMessage findLatestChatMessageInChatRoomOrThrow(Long chatRoomId) {
         ChatMessageEntity chatMessageEntity = chatMessageJpaRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(
                         chatRoomId)
-                .orElseThrow(() -> new BaseException(CustomErrorCode.CHATMESSAGE_NOT_FOUND));
+                .orElseThrow(() -> new BaseException(CHATMESSAGE_NOT_FOUND));
         return chatMessageEntity.toModel();
     }
 
+    // 내가 가장 최근에 읽은 메세지 가져오기
     @Override
     public ChatMessage findLatestReadMessageOrThrow(Long chatRoomId, Long userId) {
         return chatMessageJpaRepository
                 .findFirstByChatRoomIdAndStatusAndSenderIdNotOrderByCreatedAtDesc(chatRoomId,
                         ChatMessageStatus.READ, userId)
-                .orElseThrow(() -> new BaseException(CustomErrorCode.CHATMESSAGE_NOT_FOUND))
+                .orElseThrow(() -> new BaseException(CHATMESSAGE_NOT_FOUND))
                 .toModel();
     }
 
+    // Page number, size에 맞는 메시지 슬라이스 가져오기
     @Override
-    public List<ChatMessage> findLatestNByChatRoom(Long chatRoomId, int N) {
-        return chatMessageJpaRepository.findByChatRoomIdOrderByCreatedAtDesc(
-                        chatRoomId,
-                        PageRequest.of(0, N)
-                ).stream()
-                .map(ChatMessageEntity::toModel)
-                .toList();
+    public Slice<ChatMessage> findSliceMessages(Long chatRoomId, Pageable pageable) {
+        return chatMessageJpaRepository.findByChatRoomIdOrderByCreatedAtDesc(chatRoomId, pageable)
+                .map(ChatMessageEntity::toModel);
     }
 
     @Override
-    public List<ChatMessage> findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(Long chatRoomId,
-            Instant oldestRedisCreatedAt, int N) {
-        return chatMessageJpaRepository.findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
-                        chatRoomId,
-                        oldestRedisCreatedAt,
-                        PageRequest.of(0, N)
-                ).stream()
-                .map(ChatMessageEntity::toModel)
-                .toList();
+    public Long countByChatRoomId(Long chatRoomId) {
+        return chatMessageJpaRepository.countByChatRoomId(chatRoomId);
     }
 
 

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/JpaChatMessageDataQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/JpaChatMessageDataQueryAdapter.java
@@ -1,5 +1,6 @@
 package kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 import kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa.entity.ChatMessageEntity;
@@ -10,6 +11,7 @@ import kr.co.pawong.pwbe.chat.enums.ChatMessageStatus;
 import kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode;
 import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -40,8 +42,33 @@ public class JpaChatMessageDataQueryAdapter implements ChatMessageDataQueryPort 
     @Override
     public ChatMessage findLatestReadMessageOrThrow(Long chatRoomId, Long userId) {
         return chatMessageJpaRepository
-                .findFirstByChatRoomIdAndStatusAndSenderIdNotOrderByCreatedAtDesc(chatRoomId, ChatMessageStatus.READ, userId)
+                .findFirstByChatRoomIdAndStatusAndSenderIdNotOrderByCreatedAtDesc(chatRoomId,
+                        ChatMessageStatus.READ, userId)
                 .orElseThrow(() -> new BaseException(CustomErrorCode.CHATMESSAGE_NOT_FOUND))
                 .toModel();
     }
+
+    @Override
+    public List<ChatMessage> findLatestNByChatRoom(Long chatRoomId, int N) {
+        return chatMessageJpaRepository.findByChatRoomIdOrderByCreatedAtDesc(
+                        chatRoomId,
+                        PageRequest.of(0, N)
+                ).stream()
+                .map(ChatMessageEntity::toModel)
+                .toList();
+    }
+
+    @Override
+    public List<ChatMessage> findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(Long chatRoomId,
+            Instant oldestRedisCreatedAt, int N) {
+        return chatMessageJpaRepository.findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
+                        chatRoomId,
+                        oldestRedisCreatedAt,
+                        PageRequest.of(0, N)
+                ).stream()
+                .map(ChatMessageEntity::toModel)
+                .toList();
+    }
+
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/repository/ChatMessageJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/repository/ChatMessageJpaRepository.java
@@ -1,9 +1,11 @@
 package kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa.repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa.entity.ChatMessageEntity;
 import kr.co.pawong.pwbe.chat.enums.ChatMessageStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageEntity, Long> {
@@ -19,4 +21,20 @@ public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageEntit
             ChatMessageStatus status,
             Long readerId
     );
+
+    /**
+     * 채팅방 ID로 조회해서, createdAt 기준 내림차순 정렬 후 Pageable 만큼 가져오기
+     */
+    List<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId, Pageable pageable);
+
+    /**
+     * 채팅방 ID이면서 “createdAt < 주어진 시점”인 메시지들 중에서,
+     * createdAt 기준 내림차순 정렬 후 Pageable 만큼 가져오기
+     */
+    List<ChatMessageEntity> findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
+            Long chatRoomId,
+            Instant createdAtBefore,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/repository/ChatMessageJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/adapter/out/persistence/jpa/repository/ChatMessageJpaRepository.java
@@ -1,11 +1,11 @@
 package kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa.repository;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa.entity.ChatMessageEntity;
 import kr.co.pawong.pwbe.chat.enums.ChatMessageStatus;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageEntity, Long> {
@@ -22,19 +22,7 @@ public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageEntit
             Long readerId
     );
 
-    /**
-     * 채팅방 ID로 조회해서, createdAt 기준 내림차순 정렬 후 Pageable 만큼 가져오기
-     */
-    List<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId, Pageable pageable);
+    Slice<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId, Pageable pageable);
 
-    /**
-     * 채팅방 ID이면서 “createdAt < 주어진 시점”인 메시지들 중에서,
-     * createdAt 기준 내림차순 정렬 후 Pageable 만큼 가져오기
-     */
-    List<ChatMessageEntity> findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
-            Long chatRoomId,
-            Instant createdAtBefore,
-            Pageable pageable
-    );
-
+    Long countByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/QueryChatMessageDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/QueryChatMessageDataUseCase.java
@@ -7,5 +7,5 @@ public interface QueryChatMessageDataUseCase {
 
     List<ChatMessageDetail> findAllMessagesInChatRoom(Long userId, Long chatRoomId);
 
-    List<ChatMessageDetail> findLastestMessagesInChatRoom(Long userId, Long roomId);
+    List<ChatMessageDetail> findLatestMessagesInChatRoom(Long userId, Long roomId, Long beforeMillis);
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/QueryChatMessageDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/QueryChatMessageDataUseCase.java
@@ -1,11 +1,13 @@
 package kr.co.pawong.pwbe.chat.application.port.in;
 
 import java.util.List;
+import kr.co.pawong.pwbe.chat.adapter.in.api.dto.response.SliceChatMessagePageResponse;
 import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
+import org.springframework.data.domain.Pageable;
 
 public interface QueryChatMessageDataUseCase {
 
     List<ChatMessageDetail> findAllMessagesInChatRoom(Long userId, Long chatRoomId);
 
-    List<ChatMessageDetail> findLatestMessagesInChatRoom(Long userId, Long roomId, Long beforeMillis);
+    SliceChatMessagePageResponse getSliceMessage(Long userId, Long roomId, Pageable pageable);
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/QueryChatMessageDataUseCase.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/in/QueryChatMessageDataUseCase.java
@@ -6,4 +6,6 @@ import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
 public interface QueryChatMessageDataUseCase {
 
     List<ChatMessageDetail> findAllMessagesInChatRoom(Long userId, Long chatRoomId);
+
+    List<ChatMessageDetail> findLastestMessagesInChatRoom(Long userId, Long roomId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageCachePort.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageCachePort.java
@@ -5,7 +5,9 @@ import kr.co.pawong.pwbe.chat.domain.ChatMessage;
 
 public interface ChatMessageCachePort {
 
-    void cacheMessage(Long chatRoomId, ChatMessage chatMessage, int cacheSize);
-    List<ChatMessage> getLatestMessages(Long chatRoomId, int maxSize);
-
+    void cacheMessage(Long chatRoomId, ChatMessage chatMessage);
+    void cacheMessageChunk(List<ChatMessage> recentChatMessage, Long roomId);
+    List<ChatMessage> getLatestMessages(Long chatRoomId);
+    void updateTotalCount(Long chatRoomId, Long count);
+    Long getTotalCount(Long roomId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageCachePort.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageCachePort.java
@@ -1,0 +1,11 @@
+package kr.co.pawong.pwbe.chat.application.port.out;
+
+import java.util.List;
+import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+
+public interface ChatMessageCachePort {
+
+    void cacheMessage(Long chatRoomId, ChatMessage chatMessage, int cacheSize);
+    List<ChatMessage> getLatestMessages(Long chatRoomId, int maxSize);
+
+}

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageDataQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageDataQueryPort.java
@@ -1,5 +1,6 @@
 package kr.co.pawong.pwbe.chat.application.port.out;
 
+import java.time.Instant;
 import java.util.List;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
 
@@ -8,5 +9,6 @@ public interface ChatMessageDataQueryPort {
     List<ChatMessage> findChatMessagesByChatRoomIdInLatestOrder(Long chatRoomId);
     ChatMessage findLatestChatMessageInChatRoomOrThrow(Long chatRoomId);
     ChatMessage findLatestReadMessageOrThrow(Long chatRoomId, Long userId);
-
+    List<ChatMessage> findLatestNByChatRoom(Long chatRoomId, int N);
+    List<ChatMessage> findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(Long chatRoomId, Instant oldestRedisCreatedAt, int N);
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageDataQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/port/out/ChatMessageDataQueryPort.java
@@ -1,14 +1,15 @@
 package kr.co.pawong.pwbe.chat.application.port.out;
 
-import java.time.Instant;
 import java.util.List;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface ChatMessageDataQueryPort {
 
     List<ChatMessage> findChatMessagesByChatRoomIdInLatestOrder(Long chatRoomId);
     ChatMessage findLatestChatMessageInChatRoomOrThrow(Long chatRoomId);
     ChatMessage findLatestReadMessageOrThrow(Long chatRoomId, Long userId);
-    List<ChatMessage> findLatestNByChatRoom(Long chatRoomId, int N);
-    List<ChatMessage> findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(Long chatRoomId, Instant oldestRedisCreatedAt, int N);
+    Slice<ChatMessage> findSliceMessages(Long chatRoomId, Pageable pageable);
+    Long countByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
@@ -51,64 +51,95 @@ public class QueryChatMessageDataService implements QueryChatMessageDataUseCase 
                 .collect(Collectors.toList());
     }
 
+    /**
+     * “beforeMillis == null” → 가장 최신 페이지 용 호출
+     * “beforeMillis != null” → 과거 페이지 용 호출
+     * @param userId
+     * @param roomId
+     * @param beforeMillis
+     * @return
+     */
     @Override
-    public List<ChatMessageDetail> findLastestMessagesInChatRoom(Long userId, Long roomId) {
+    public List<ChatMessageDetail> findLatestMessagesInChatRoom(Long userId, Long roomId, Long beforeMillis) {
+        if (!queryChatRoomDataUseCase.isUserInChatRoom(userId, roomId)) {
+            throw new BaseException(CustomErrorCode.FORBIDDEN_CHATMESSAGE_QUERY);
+        }
+        if (beforeMillis == null) return fetchLatestPage(roomId);
+        return fetchOlderPage(roomId, beforeMillis);
+    }
 
+    /**
+     * 채팅방의 최신 N건의 메세지를 반환
+     * @param roomId
+     * @return
+     */
+    private List<ChatMessageDetail> fetchLatestPage(Long roomId) {
         // 1) Redis 에서 최신 PAGE_SIZE건 조회
-        List<ChatMessageDetail> latestMessages =
-                chatMessageCachePort.getLatestMessages(roomId, CACHE_PAGE_SIZE)
-                        .stream()
-                        .map(msg -> {
-                                    User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
-                                    return ChatMessageDetail
-                                            .from(msg)
-                                            .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
-                                }
-                        )
-                        .toList();
-        if (latestMessages.size() == CACHE_PAGE_SIZE)
-            return latestMessages;
+        List<ChatMessage> cached = chatMessageCachePort.getLatestMessages(roomId, CACHE_PAGE_SIZE);
 
-        // 2) Redis 데이터가 없으면
-        if(latestMessages.isEmpty()) {
-            List<ChatMessage> fromDb = chatMessageDataQueryPort.findLatestNByChatRoom(roomId, CACHE_PAGE_SIZE);
-            Collections.reverse(fromDb);
-            return fromDb.stream()
-                    .map(msg -> {
-                        User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
-                        return ChatMessageDetail
-                                .from(msg)
-                                .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
-                    })
+        if (cached.size() == CACHE_PAGE_SIZE) {
+            return cached.stream()
+                    .map(this::toDetailWithSender)
                     .collect(Collectors.toList());
         }
 
-        // 2) Redis에 충분한 데이터가 없으면, DB에서 추가 조회하여 반환
-        int need = CACHE_PAGE_SIZE-latestMessages.size();
-        Instant oldestRedisCreatedAt = Instant.ofEpochMilli(latestMessages.getFirst().getCreatedAt());
+        // 2) Redis 데이터가 없으면
+        if(cached.isEmpty()) {
+            List<ChatMessage> fromDb = chatMessageDataQueryPort.findLatestNByChatRoom(roomId, CACHE_PAGE_SIZE);
+            Collections.reverse(fromDb);
+            return fromDb.stream()
+                    .map(this::toDetailWithSender)
+                    .collect(Collectors.toList());
+        }
+
+        // 3) Redis에 충분한 데이터가 없으면, DB에서 추가 조회하여 반환
+        int need = CACHE_PAGE_SIZE-cached.size();
+        Instant oldestRedisCreatedAt = cached.getFirst().getCreatedAt();
         List<ChatMessage> dbList = chatMessageDataQueryPort
                 .findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
                         roomId,
                         oldestRedisCreatedAt,
                         need
                 );
-
-        // 3) DB 엔티티 → DTO로 변환 후, "역순(시간 오름차순)"으로 맞춘 다음 Redis 리스트 뒤에 붙임
-        List<ChatMessageDetail> dbDtoList = dbList.stream()
-                .map(msg -> {
-                    User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
-                    return ChatMessageDetail
-                            .from(msg)
-                            .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
-                })
-                .sorted(Comparator.comparingLong(ChatMessageDetail::getCreatedAt))
-                .toList();
         Collections.reverse(dbList);
 
         // 4) 최종 반환 리스트: (DB 쪽 과거 메시지들) + (Redis 쪽 최신 메시지들)
         List<ChatMessageDetail> result = new ArrayList<>();
-        result.addAll(dbDtoList);
-        result.addAll(latestMessages);
+        dbList.forEach(msg -> result.add(toDetailWithSender(msg)));
+        cached.forEach(msg -> result.add(toDetailWithSender(msg)));
         return result;
+    }
+
+    /**
+     * Redis에 beforeMillis 이전 메시지가 충분히 없다면 DB에서 보충 조회한 다음 오름차순으로 합쳐서 반환
+     * @param roomId
+     * @param beforeMillis
+     * @return
+     */
+    private List<ChatMessageDetail> fetchOlderPage(Long roomId, Long beforeMillis) {
+        // 1) DB에서 “createdAt < beforeInstant”, 내림차순으로 최대 N건 가져오기
+        Instant beforeInstant = Instant.ofEpochMilli(beforeMillis);
+        List<ChatMessage> dbList = chatMessageDataQueryPort
+                .findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
+                        roomId,
+                        beforeInstant,
+                        CACHE_PAGE_SIZE
+                );
+
+        // 2) “과거→최신” 순서로 뒤집기
+        Collections.reverse(dbList);
+
+        // 3) DTO 변환 + 보낸 사람 정보 채우기
+        return dbList.stream()
+                .map(this::toDetailWithSender)
+                .collect(Collectors.toList());
+    }
+
+    // ChatMessage → ChatMessageDetail + senderName, senderProfileImage 채워서 반환
+    private ChatMessageDetail toDetailWithSender(ChatMessage msg) {
+        User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
+        return ChatMessageDetail
+                .from(msg)
+                .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
@@ -1,10 +1,15 @@
 package kr.co.pawong.pwbe.chat.application.service;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import kr.co.pawong.pwbe.chat.application.port.in.QueryChatMessageDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.QueryChatRoomDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
+import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageCachePort;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageDataQueryPort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
 import kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode;
@@ -18,9 +23,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class QueryChatMessageDataService implements QueryChatMessageDataUseCase {
 
+    private static final int CACHE_PAGE_SIZE = 50;
+
     private final QueryChatRoomDataUseCase queryChatRoomDataUseCase;
     private final ChatMessageDataQueryPort chatMessageDataQueryPort;
     private final UserDataQueryPort userDataQueryPort;
+    private final ChatMessageCachePort chatMessageCachePort;
 
     @Override
     public List<ChatMessageDetail> findAllMessagesInChatRoom(Long userId, Long chatRoomId) {
@@ -41,5 +49,66 @@ public class QueryChatMessageDataService implements QueryChatMessageDataUseCase 
                     }
                 )
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ChatMessageDetail> findLastestMessagesInChatRoom(Long userId, Long roomId) {
+
+        // 1) Redis 에서 최신 PAGE_SIZE건 조회
+        List<ChatMessageDetail> latestMessages =
+                chatMessageCachePort.getLatestMessages(roomId, CACHE_PAGE_SIZE)
+                        .stream()
+                        .map(msg -> {
+                                    User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
+                                    return ChatMessageDetail
+                                            .from(msg)
+                                            .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
+                                }
+                        )
+                        .toList();
+        if (latestMessages.size() == CACHE_PAGE_SIZE)
+            return latestMessages;
+
+        // 2) Redis 데이터가 없으면
+        if(latestMessages.isEmpty()) {
+            List<ChatMessage> fromDb = chatMessageDataQueryPort.findLatestNByChatRoom(roomId, CACHE_PAGE_SIZE);
+            Collections.reverse(fromDb);
+            return fromDb.stream()
+                    .map(msg -> {
+                        User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
+                        return ChatMessageDetail
+                                .from(msg)
+                                .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        // 2) Redis에 충분한 데이터가 없으면, DB에서 추가 조회하여 반환
+        int need = CACHE_PAGE_SIZE-latestMessages.size();
+        Instant oldestRedisCreatedAt = Instant.ofEpochMilli(latestMessages.getFirst().getCreatedAt());
+        List<ChatMessage> dbList = chatMessageDataQueryPort
+                .findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
+                        roomId,
+                        oldestRedisCreatedAt,
+                        need
+                );
+
+        // 3) DB 엔티티 → DTO로 변환 후, "역순(시간 오름차순)"으로 맞춘 다음 Redis 리스트 뒤에 붙임
+        List<ChatMessageDetail> dbDtoList = dbList.stream()
+                .map(msg -> {
+                    User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
+                    return ChatMessageDetail
+                            .from(msg)
+                            .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
+                })
+                .sorted(Comparator.comparingLong(ChatMessageDetail::getCreatedAt))
+                .toList();
+        Collections.reverse(dbList);
+
+        // 4) 최종 반환 리스트: (DB 쪽 과거 메시지들) + (Redis 쪽 최신 메시지들)
+        List<ChatMessageDetail> result = new ArrayList<>();
+        result.addAll(dbDtoList);
+        result.addAll(latestMessages);
+        return result;
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/QueryChatMessageDataService.java
@@ -1,29 +1,33 @@
 package kr.co.pawong.pwbe.chat.application.service;
 
-import java.time.Instant;
+import static kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode.*;
+
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import kr.co.pawong.pwbe.chat.adapter.in.api.dto.response.SliceChatMessagePageResponse;
+import kr.co.pawong.pwbe.chat.adapter.out.persistence.jpa.entity.ChatMessageEntity;
 import kr.co.pawong.pwbe.chat.application.port.in.QueryChatMessageDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.QueryChatRoomDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.dto.ChatMessageDetail;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageCachePort;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageDataQueryPort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
-import kr.co.pawong.pwbe.global.error.errorcode.CustomErrorCode;
 import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.user.application.port.out.UserDataQueryPort;
 import kr.co.pawong.pwbe.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class QueryChatMessageDataService implements QueryChatMessageDataUseCase {
-
-    private static final int CACHE_PAGE_SIZE = 50;
 
     private final QueryChatRoomDataUseCase queryChatRoomDataUseCase;
     private final ChatMessageDataQueryPort chatMessageDataQueryPort;
@@ -34,7 +38,7 @@ public class QueryChatMessageDataService implements QueryChatMessageDataUseCase 
     public List<ChatMessageDetail> findAllMessagesInChatRoom(Long userId, Long chatRoomId) {
         // 유저가 해당 채팅방에 속하지 않다면 예외를 발생
         if (!queryChatRoomDataUseCase.isUserInChatRoom(userId, chatRoomId)) {
-            throw new BaseException(CustomErrorCode.FORBIDDEN_CHATMESSAGE_QUERY);
+            throw new BaseException(FORBIDDEN_CHATMESSAGE_QUERY);
         }
 
         List<ChatMessage> chatMessages = chatMessageDataQueryPort
@@ -42,100 +46,91 @@ public class QueryChatMessageDataService implements QueryChatMessageDataUseCase 
 
         return chatMessages.stream()
                 .map(msg -> {
-                    User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
-                    return ChatMessageDetail
+                            User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
+                            return ChatMessageDetail
                                     .from(msg)
                                     .updateSenderInfo(sender.getNickname(), sender.getProfileImage());
-                    }
+                        }
                 )
                 .collect(Collectors.toList());
     }
 
     /**
-     * “beforeMillis == null” → 가장 최신 페이지 용 호출
-     * “beforeMillis != null” → 과거 페이지 용 호출
+     * page number에 따라서 메세지를 슬라이싱하여 반환한다
+     * 첫 페이지 로드일 때에는 findLatestMessagesInChatRoom
+     * 이후 페이지 로드 때에는 findOlderMessagesInChatRoom
      * @param userId
      * @param roomId
-     * @param beforeMillis
+     * @param pageable
      * @return
      */
     @Override
-    public List<ChatMessageDetail> findLatestMessagesInChatRoom(Long userId, Long roomId, Long beforeMillis) {
+    public SliceChatMessagePageResponse getSliceMessage(Long userId, Long roomId, Pageable pageable) {
         if (!queryChatRoomDataUseCase.isUserInChatRoom(userId, roomId)) {
-            throw new BaseException(CustomErrorCode.FORBIDDEN_CHATMESSAGE_QUERY);
+            throw new BaseException(FORBIDDEN_CHATMESSAGE_QUERY);
         }
-        if (beforeMillis == null) return fetchLatestPage(roomId);
-        return fetchOlderPage(roomId, beforeMillis);
+
+        if(pageable.getPageNumber() == 0)
+            return findLatestMessagesInChatRoom(roomId, pageable);
+
+        return findOlderMessagesInChatRoom(roomId, pageable);
     }
 
     /**
-     * 채팅방의 최신 N건의 메세지를 반환
+     * 최근 메세지를 반환한다
+     * 처음으로 캐시에서 데이터를 가져오는 경우 전체 데이터의 개수를 계산하여 HasNext를 반환한다
+     * 만약 캐시의 데이터가 page size 만큼 존재하지 않으면 DB에서 데이터를 가져온 뒤에 캐시에 저장한다
      * @param roomId
-     * @return
+     * @param pageable
+     * @return SliceChatMessagePageResponse
      */
-    private List<ChatMessageDetail> fetchLatestPage(Long roomId) {
-        // 1) Redis 에서 최신 PAGE_SIZE건 조회
-        List<ChatMessage> cached = chatMessageCachePort.getLatestMessages(roomId, CACHE_PAGE_SIZE);
+    private SliceChatMessagePageResponse findLatestMessagesInChatRoom(Long roomId, Pageable pageable) {
 
-        if (cached.size() == CACHE_PAGE_SIZE) {
-            return cached.stream()
-                    .map(this::toDetailWithSender)
-                    .collect(Collectors.toList());
+        /* get messages from cache */
+        List<ChatMessage> recentChatMessage = chatMessageCachePort.getLatestMessages(roomId);
+        Long totalCount = chatMessageCachePort.getTotalCount(roomId);
+        if(totalCount==0)  updateCacheTotalCount(roomId);
+        boolean hasNext = totalCount > recentChatMessage.size();
+
+        /* get messages from a database */
+        if(recentChatMessage.size() < pageable.getPageSize()) {
+            Slice<ChatMessage> sliceMessages = chatMessageDataQueryPort.findSliceMessages(roomId, PageRequest.of(0, pageable.getPageSize()));
+            List<ChatMessage> chatMessageList = new ArrayList<>(sliceMessages.getContent());
+            Collections.reverse(chatMessageList);
+            hasNext = sliceMessages.hasNext();
+
+            /* save to cache */
+            recentChatMessage = chatMessageList;
+            chatMessageCachePort.cacheMessageChunk(chatMessageList, roomId);
+            updateCacheTotalCount(roomId);
         }
 
-        // 2) Redis 데이터가 없으면
-        if(cached.isEmpty()) {
-            List<ChatMessage> fromDb = chatMessageDataQueryPort.findLatestNByChatRoom(roomId, CACHE_PAGE_SIZE);
-            Collections.reverse(fromDb);
-            return fromDb.stream()
-                    .map(this::toDetailWithSender)
-                    .collect(Collectors.toList());
-        }
+        List<ChatMessageDetail> chatMessageDetails = recentChatMessage.stream().map(this::toDetailWithSender).toList();
+        return new SliceChatMessagePageResponse(chatMessageDetails, hasNext, 0, chatMessageDetails.size());
+    }
 
-        // 3) Redis에 충분한 데이터가 없으면, DB에서 추가 조회하여 반환
-        int need = CACHE_PAGE_SIZE-cached.size();
-        Instant oldestRedisCreatedAt = cached.getFirst().getCreatedAt();
-        List<ChatMessage> dbList = chatMessageDataQueryPort
-                .findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
-                        roomId,
-                        oldestRedisCreatedAt,
-                        need
-                );
-        Collections.reverse(dbList);
-
-        // 4) 최종 반환 리스트: (DB 쪽 과거 메시지들) + (Redis 쪽 최신 메시지들)
-        List<ChatMessageDetail> result = new ArrayList<>();
-        dbList.forEach(msg -> result.add(toDetailWithSender(msg)));
-        cached.forEach(msg -> result.add(toDetailWithSender(msg)));
-        return result;
+    private void updateCacheTotalCount(Long roomId) {
+        Long count = chatMessageDataQueryPort.countByChatRoomId(roomId);
+        chatMessageCachePort.updateTotalCount(roomId, count);
     }
 
     /**
-     * Redis에 beforeMillis 이전 메시지가 충분히 없다면 DB에서 보충 조회한 다음 오름차순으로 합쳐서 반환
+     * 이전 메세지들은 데이터베이스에서 조회하여 반환한다.
      * @param roomId
-     * @param beforeMillis
-     * @return
+     * @param pageable
+     * @return SliceChatMessagePageResponse
      */
-    private List<ChatMessageDetail> fetchOlderPage(Long roomId, Long beforeMillis) {
-        // 1) DB에서 “createdAt < beforeInstant”, 내림차순으로 최대 N건 가져오기
-        Instant beforeInstant = Instant.ofEpochMilli(beforeMillis);
-        List<ChatMessage> dbList = chatMessageDataQueryPort
-                .findByChatRoomIdAndCreatedAtBeforeOrderByCreatedAtDesc(
-                        roomId,
-                        beforeInstant,
-                        CACHE_PAGE_SIZE
-                );
+    private SliceChatMessagePageResponse findOlderMessagesInChatRoom(Long roomId, Pageable pageable) {
+        Slice<ChatMessage> sliceMessages = chatMessageDataQueryPort.findSliceMessages(roomId, pageable);
+        List<ChatMessage> chatMessageList = new ArrayList<>(sliceMessages.getContent());
+        Collections.reverse(chatMessageList);
+        boolean hasNext = sliceMessages.hasNext();
 
-        // 2) “과거→최신” 순서로 뒤집기
-        Collections.reverse(dbList);
-
-        // 3) DTO 변환 + 보낸 사람 정보 채우기
-        return dbList.stream()
-                .map(this::toDetailWithSender)
-                .collect(Collectors.toList());
+        List<ChatMessageDetail> chatMessageDetails = chatMessageList.stream().map(this::toDetailWithSender).toList();
+        return new SliceChatMessagePageResponse(chatMessageDetails, hasNext, pageable.getPageNumber(), chatMessageDetails.size());
     }
 
-    // ChatMessage → ChatMessageDetail + senderName, senderProfileImage 채워서 반환
+    // TODO: ChatMessage 마다 사용자 정보를 가져오는 로직 리팩토링
     private ChatMessageDetail toDetailWithSender(ChatMessage msg) {
         User sender = userDataQueryPort.findByUserIdOrThrow(msg.getSenderId());
         return ChatMessageDetail

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
@@ -17,8 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCase {
 
-    private static final int MAX_CACHE_SIZE = 100;
-
     private final CommandChatMessageDataUseCase commandChatMessageDataUseCase;
     private final ChatMessageDataQueryPort chatMessageDataQueryPort;
     private final ApplicationEventPublisher publisher;
@@ -30,7 +28,7 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
     public void createAndSendChatMessage(ChatMessageCreateRequest request, Long chatRoomId,
             Long userId) {
         ChatMessage chatMessage = createChatMessage(request, chatRoomId, userId);
-        chatMessageCachePort.cacheMessage(chatRoomId, chatMessage, MAX_CACHE_SIZE);
+        chatMessageCachePort.cacheMessage(chatRoomId, chatMessage);
         publisher.publishEvent(new ChatMessageCreatedEvent(chatMessage));
     }
 
@@ -39,6 +37,7 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
     public void readMessage(Long roomId, Long userId) {
         commandChatMessageDataUseCase.markAllAsRead(roomId, userId);
         ChatMessage chatMessage = chatMessageDataQueryPort.findLatestReadMessageOrThrow(roomId, userId);
+        if(chatMessage == null) return;
         publisher.publishEvent(new ChatMessageReadEvent(roomId, userId, chatMessage.getMessageId()));
     }
 

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
@@ -8,6 +8,7 @@ import kr.co.pawong.pwbe.chat.application.port.in.SendChatMessageBrokerUseCase;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageCachePort;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageDataQueryPort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -36,9 +37,13 @@ public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCas
     @Transactional
     public void readMessage(Long roomId, Long userId) {
         commandChatMessageDataUseCase.markAllAsRead(roomId, userId);
-        ChatMessage chatMessage = chatMessageDataQueryPort.findLatestReadMessageOrThrow(roomId, userId);
-        if(chatMessage == null) return;
-        publisher.publishEvent(new ChatMessageReadEvent(roomId, userId, chatMessage.getMessageId()));
+        try {
+            ChatMessage chatMessage = chatMessageDataQueryPort.findLatestReadMessageOrThrow(roomId,
+                    userId);
+            publisher.publishEvent(new ChatMessageReadEvent(roomId, userId, chatMessage.getMessageId()));
+        } catch (BaseException e) {
+            return;
+        }
     }
 
     private ChatMessage createChatMessage(ChatMessageCreateRequest request, Long chatRoomId,

--- a/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
+++ b/src/main/java/kr/co/pawong/pwbe/chat/application/service/SendChatMessageBrokerService.java
@@ -5,6 +5,7 @@ import kr.co.pawong.pwbe.chat.application.listener.event.ChatMessageCreatedEvent
 import kr.co.pawong.pwbe.chat.application.listener.event.ChatMessageReadEvent;
 import kr.co.pawong.pwbe.chat.application.port.in.CommandChatMessageDataUseCase;
 import kr.co.pawong.pwbe.chat.application.port.in.SendChatMessageBrokerUseCase;
+import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageCachePort;
 import kr.co.pawong.pwbe.chat.application.port.out.ChatMessageDataQueryPort;
 import kr.co.pawong.pwbe.chat.domain.ChatMessage;
 import lombok.RequiredArgsConstructor;
@@ -16,15 +17,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SendChatMessageBrokerService implements SendChatMessageBrokerUseCase {
 
+    private static final int MAX_CACHE_SIZE = 100;
+
     private final CommandChatMessageDataUseCase commandChatMessageDataUseCase;
     private final ChatMessageDataQueryPort chatMessageDataQueryPort;
     private final ApplicationEventPublisher publisher;
+    private final ChatMessageCachePort chatMessageCachePort;
+
 
     @Override
     @Transactional
     public void createAndSendChatMessage(ChatMessageCreateRequest request, Long chatRoomId,
             Long userId) {
         ChatMessage chatMessage = createChatMessage(request, chatRoomId, userId);
+        chatMessageCachePort.cacheMessage(chatRoomId, chatMessage, MAX_CACHE_SIZE);
         publisher.publishEvent(new ChatMessageCreatedEvent(chatMessage));
     }
 

--- a/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
@@ -79,6 +79,8 @@ public enum CustomErrorCode implements ErrorCode {
     NOTIFICATION_ADOPTION_SEND_ERROR(INTERNAL_SERVER_ERROR, "유사 공고 알림 발송에 실패하였습니다."),
     EMAIL_SEND_FAIL(INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다."),
     REDIS_SAVE_ERROR(INTERNAL_SERVER_ERROR,"REDIS 저장에 실패하였습니다."),
+    CHATMESSAGE_PARSE_ERROR(INTERNAL_SERVER_ERROR, "채팅 메시지가 파싱 실패하였습니다."),
+
     // 검색
     SEARCH_ERROR(SERVICE_UNAVAILABLE, "검색 기능이 정상적으로 동작하지 않습니다."),
 


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#89 -> develop

### 변경 사항
**1. 채팅 메세지 전송시 레디스에 캐싱**

**2. 채팅 메세지 조회, 기본 페이지 사이즈를 50으로 설정했습니다.**
    1) page = 0
    - 레디스에서 50건 조회 요청
    - 캐싱된 데이터가 충분하지 않을 경우 데이터베이스에서 가져옴
    - 데이터베이스 가져온 데이터를 캐싱
    2) page >= 1
    - 데이터베이스에서 로드

**3. 데이터 총 개수 동기화**
    - 처음으로 캐싱 데이터 가져올 때
    - 캐싱 데이터가 없어서 데이터베이스에서 가져온 뒤 캐싱할 때

**4. 페이지 사이즈와 캐시 최대 사이즈를 50으로 설정**


### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과

