### PR TITLE
[PW-106] ES에 있지만, RDB에 없을 경우 ES에서 해당 데이터 삭제

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/error/errorcode/CustomErrorCode.java
@@ -70,6 +70,7 @@ public enum CustomErrorCode implements ErrorCode {
     SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버와의 연결에 실패하였습니다."),
     DATABASE_ERROR(INTERNAL_SERVER_ERROR, "데이터베이스 연결에 실패하였습니다."),
     ES_SAVE_ERROR(INTERNAL_SERVER_ERROR, "Elasticsearch 저장에 실패하였습니다."),
+    ES_DELETE_ERROR(INTERNAL_SERVER_ERROR, "Elasticsearch에서 삭제하는데 실패하였습니다."),
     KAFKA_MESSAGE_PUBLISH_ERROR(INTERNAL_SERVER_ERROR, "Kafka 메시지 발행에 실패하였습니다."),
     KAFKA_CONNECTION_ERROR(INTERNAL_SERVER_ERROR, "Kafka 서버 연결에 실패하였습니다."),
     NOTIFICATION_SAVE_ERROR(INTERNAL_SERVER_ERROR, "알림 저장에 실패하였습니다."),
@@ -85,8 +86,7 @@ public enum CustomErrorCode implements ErrorCode {
     SEARCH_ERROR(SERVICE_UNAVAILABLE, "검색 기능이 정상적으로 동작하지 않습니다."),
 
     // 이메일
-    EMAIL_DUPLICATE(CONFLICT, "사용 중인 이메일입니다.")
-    ;
+    EMAIL_DUPLICATE(CONFLICT, "사용 중인 이메일입니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/es/EsLostAnimalEngineCommandAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/es/EsLostAnimalEngineCommandAdapter.java
@@ -21,7 +21,7 @@ public class EsLostAnimalEngineCommandAdapter implements LostAnimalEngineCommand
     private static final IndexCoordinates INDEX = IndexCoordinates.of("lost_animal");
 
     @Override
-    public void saveLostAnimalToEs(LostAnimalDto lostAnimalDto) {
+    public void saveLostAnimal(LostAnimalDto lostAnimalDto) {
         if (lostAnimalDto == null) {
             return;
         }
@@ -29,8 +29,22 @@ public class EsLostAnimalEngineCommandAdapter implements LostAnimalEngineCommand
             LostAnimalDocument document = LostAnimalDocument.from(lostAnimalDto);
             elasticsearchOperations.save(document, INDEX);
         } catch (Exception e) {
-            log.error("LostAnimal ES 저장이 실패하였습니다.", e);
+            log.error("LostAnimal ES 저장이 실패하였습니다. type={}, id={}",
+                    lostAnimalDto.getType(), lostAnimalDto.getLostAnimalId(), e);
             throw new BaseException(CustomErrorCode.ES_SAVE_ERROR, e);
+        }
+    }
+
+    @Override
+    public void deleteLostAnimal(String lostAnimalId) {
+        if (lostAnimalId == null || lostAnimalId.isBlank()) {
+            return;
+        }
+        try {
+            elasticsearchOperations.delete(lostAnimalId, INDEX);
+        } catch (Exception e) {
+            log.error("LostAnimal ES 삭제에 실패하였습니다. id={}", lostAnimalId, e);
+            throw new BaseException(CustomErrorCode.ES_DELETE_ERROR, e);
         }
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostAnimalEngineCommandPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostAnimalEngineCommandPort.java
@@ -4,6 +4,8 @@ import kr.co.pawong.pwbe.lostPost.application.port.out.dto.LostAnimalDto;
 
 public interface LostAnimalEngineCommandPort {
 
-    void saveLostAnimalToEs(LostAnimalDto lostAnimalDto);
+    void saveLostAnimal(LostAnimalDto lostAnimalDto);
+
+    void deleteLostAnimal(String lostAnimalId);
 
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/IndexLostAnimalService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/IndexLostAnimalService.java
@@ -31,7 +31,7 @@ public class IndexLostAnimalService implements IndexLostAnimalUseCase {
                 LostAnimalDto lostPostDto = LostAnimalDto.fromLostPost(lostPost, type, embedding);
 
                 // ES에 저장
-                lostAnimalEngineCommandPort.saveLostAnimalToEs(lostPostDto);
+                lostAnimalEngineCommandPort.saveLostAnimal(lostPostDto);
             }
             case PostType.FOSTER -> {
                 // 구조 API 데이터 가져오기
@@ -42,7 +42,7 @@ public class IndexLostAnimalService implements IndexLostAnimalUseCase {
                         embedding);
 
                 // ES에 저장
-                lostAnimalEngineCommandPort.saveLostAnimalToEs(lostAdoptionDto);
+                lostAnimalEngineCommandPort.saveLostAnimal(lostAdoptionDto);
             }
             default -> throw new IllegalStateException("Unexpected PostType: " + type.name());
         }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
@@ -3,26 +3,32 @@ package kr.co.pawong.pwbe.lostPost.application.service;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import kr.co.pawong.pwbe.adoption.application.port.out.ProxyUrlPort;
+import kr.co.pawong.pwbe.global.error.exception.BaseException;
 import kr.co.pawong.pwbe.infrastructure.s3.application.port.out.ImageStoragePort;
 import kr.co.pawong.pwbe.lostPost.application.port.in.QueryLostAnimalDataUseCase;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostAnimalQuery;
 import kr.co.pawong.pwbe.lostPost.application.port.in.dto.LostPostCard;
 import kr.co.pawong.pwbe.lostPost.application.port.in.mapper.LostPostCardMapper;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostAdoptionDataQueryPort;
+import kr.co.pawong.pwbe.lostPost.application.port.out.LostAnimalEngineCommandPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.LostPostDataQueryPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.ShelterCareNmPort;
 import kr.co.pawong.pwbe.lostPost.application.port.out.UserInfoPort;
 import kr.co.pawong.pwbe.lostPost.domain.LostAdoption;
 import kr.co.pawong.pwbe.lostPost.domain.LostPost;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
 
+    private final LostAnimalEngineCommandPort lostAnimalEngineCommandPort;
     private final LostAdoptionDataQueryPort lostAdoptionDataQueryPort;
     private final LostPostDataQueryPort lostPostDataQueryPort;
     private final ShelterCareNmPort shelterCareNmPort;
@@ -37,16 +43,20 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
     public List<LostPostCard> getLostAnimalsByIds(List<LostAnimalQuery> lostAnimalQueries) {
 
         return lostAnimalQueries.stream()
-                .map(this::convertToLostPostCard)
+                .map(this::convertToLostPostCardOrNull)
+                .filter(Objects::nonNull)
                 .toList();
     }
 
-    private LostPostCard convertToLostPostCard(LostAnimalQuery lostAnimalQuery) {
+    // TODO: 리팩터링 필요...
+    private LostPostCard convertToLostPostCardOrNull(LostAnimalQuery lostAnimalQuery) {
         return switch (lostAnimalQuery.type()) {
             // Lost Post 가져오기
             case LOST_POST -> {
-                LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(
-                        lostAnimalQuery.id());
+                LostPost lostPost = getLostPostByIdOrDeleteFromEngine(lostAnimalQuery);
+                if (lostPost == null) {
+                    yield null;
+                }
                 // 작성자 이름 조회
                 String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
                 String url = imageStoragePort.presignDownload(lostPost.getImageKey(), DOWNLOAD_URL_EXPIRE).toString();
@@ -54,8 +64,10 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
             }
             // Lost Adoption 가져오기
             case LOST_ADOPTION -> {
-                LostAdoption lostAdoption = lostAdoptionDataQueryPort.findAdoptionByIdOrThrow(
-                        lostAnimalQuery.id());
+                LostAdoption lostAdoption = getLostAdoptionByIdOrDeleteFromEngine(lostAnimalQuery);
+                if (lostAdoption == null) {
+                    yield null;
+                }
                 changePopfilesToProxy(lostAdoption);
                 // 보호소 이름 조회
                 String shelter = shelterCareNmPort.getShelterCareNmByCareRegNo(
@@ -63,6 +75,39 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
                 yield LostPostCardMapper.toLostPostCard(lostAdoption, shelter, clock);
             }
         };
+    }
+
+    private LostPost getLostPostByIdOrDeleteFromEngine(LostAnimalQuery lostAnimalQuery) {
+        try {
+            return lostPostDataQueryPort.findLostPostByIdOrThrow(lostAnimalQuery.id());
+        } catch (BaseException e) {
+            // ES_에서 해당 데이터 삭제 -> ES와 RDB 싱크 맞추기
+            // TODO: 현재 함수 구성으로는 FOUND인지 LOST인지 알 수 없어서 둘 다 삭제하게 했습니다...
+            lostAnimalEngineCommandPort.deleteLostAnimal(
+                    "FOUND_" + lostAnimalQuery.id()
+            );
+            lostAnimalEngineCommandPort.deleteLostAnimal(
+                    "LOST_" + lostAnimalQuery.id()
+            );
+            log.info("RDB에 없는 ES 데이터여서 ES에서 삭제합니다. type: {}, id: {}",
+                    lostAnimalQuery.type().name(), lostAnimalQuery.id());
+            return null;
+        }
+    }
+
+    private LostAdoption getLostAdoptionByIdOrDeleteFromEngine(LostAnimalQuery lostAnimalQuery) {
+        try {
+            return lostAdoptionDataQueryPort.findAdoptionByIdOrThrow(
+                    lostAnimalQuery.id());
+        } catch (BaseException e) {
+            // ES_에서 해당 데이터 삭제 -> ES와 RDB 싱크 맞추기
+            // TODO: 현재 하드코딩 됨. 추후 이 클래스의 조회 로직 자체를 아예 리팩토링 해야 할 것 같습니다..
+            lostAnimalEngineCommandPort.deleteLostAnimal(
+                    "FOSTER_" + lostAnimalQuery.id()
+            );
+            log.info("RDB에 없는 ES 데이터여서 ES에서 삭제합니다. type: FOSTER, id: {}", lostAnimalQuery.id());
+            return null;
+        }
     }
 
     private void changePopfilesToProxy(LostAdoption lostAdoption) {


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#106 -> develop

### 변경 사항
ES에 있지만 RDB에 없을 경우 해당 데이터를 ES에서 삭제합니다.
이제 SSE 에러가 발생하지 않을 것 같습니다. 이거를 놓쳤네요 ㅜㅜ

현재 조회하고 삭제하는 로직에서 이게 LOST인지 FOUND인지 판단이 불가능해서 LOST와 FOUND를 ES에서 둘 다 삭제하게 했습니다.
그래서 postId가 5면, ES에서 FOUND_5와  LOST_5를 둘 다 삭제합니다. (LOST와 FOUND는 id가 겹칠일이 없습니다.)
추후 해당 클래스 전체 로직 자체를 뜯어 고치겠습니다.

### PR 체크리스트
- [ ] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과
![image](https://github.com/user-attachments/assets/85a5110b-3449-4ab6-a583-c8f21df12037)
