### PR TITLE
[PW-114] soft delete된 lost post 엔티티 조회하는 native query 메소드 추가

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/JpaLostPostDataQueryAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/JpaLostPostDataQueryAdapter.java
@@ -23,14 +23,26 @@ public class JpaLostPostDataQueryAdapter implements LostPostDataQueryPort {
     private final LostPostJpaRepository lostPostJpaRepository;
     private final LostPostQueryBuilder lostPostQueryBuilder;
 
+    // active인 lost post만 조회
     @Override
-    public LostPost findLostPostByIdOrThrow(Long lostPostId) {
+    public LostPost findActiveLostPostByIdOrThrow(Long lostPostId) {
         LostPostEntity entity = lostPostJpaRepository.findById(lostPostId)
                 .orElseThrow(() ->
                         new BaseException(LOST_NOT_FOUND));
 
         return entity.toDomain();
     }
+
+    // active, inactive 상태 모두 조회
+    @Override
+    public LostPost findAnyLostPostByIdOrThrow(Long lostPostId) {
+        LostPostEntity entity = lostPostJpaRepository.findAnyByLostPostId(lostPostId)
+                .orElseThrow(() ->
+                        new BaseException(LOST_NOT_FOUND));
+
+        return entity.toDomain();
+    }
+
 
     @Override
     public List<LostPost> getLostPostsByUserId(Long userId) {

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/repository/LostPostJpaRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/adapter/out/persistence/jpa/repository/LostPostJpaRepository.java
@@ -8,6 +8,8 @@ import kr.co.pawong.pwbe.lostPost.enums.PostType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LostPostJpaRepository extends JpaRepository<LostPostEntity, Long> {
 
@@ -16,4 +18,8 @@ public interface LostPostJpaRepository extends JpaRepository<LostPostEntity, Lon
     Page<LostPostEntity> findByPostType(PostType type, Pageable pageable);
 
     Optional<LostPostEntity> findByLostPostIdAndStatus(Long postId, PostStatus postStatus);
+
+    // soft delete 무관하게 모두 조회
+    @Query(value = "SELECT * FROM lost_posts WHERE lost_post_id = :lostPostId", nativeQuery = true)
+    Optional<LostPostEntity> findAnyByLostPostId(@Param("lostPostId") Long lostPostId);
 }

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostPostDataQueryPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/port/out/LostPostDataQueryPort.java
@@ -11,7 +11,9 @@ public interface LostPostDataQueryPort {
 
     List<LostPost> getLostPostsByUserId(Long userId);
 
-    LostPost findLostPostByIdOrThrow(Long lostPostId);
+    LostPost findActiveLostPostByIdOrThrow(Long lostPostId);
+
+    LostPost findAnyLostPostByIdOrThrow(Long lostPostId);
 
     Page<LostPost> getLostPostsByPostTypePaged(Pageable pageable, PostType type);
 

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/IndexLostAnimalService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/IndexLostAnimalService.java
@@ -25,7 +25,7 @@ public class IndexLostAnimalService implements IndexLostAnimalUseCase {
         switch (type) {
             case PostType.FOUND, PostType.LOST -> {
                 // 발견 게시물 데이터 가져오기
-                LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(id);
+                LostPost lostPost = lostPostDataQueryPort.findActiveLostPostByIdOrThrow(id);
 
                 // lostPost -> lostAnimalDto
                 LostAnimalDto lostPostDto = LostAnimalDto.fromLostPost(lostPost, type, embedding);

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostAnimalDataService.java
@@ -80,7 +80,7 @@ public class QueryLostAnimalDataService implements QueryLostAnimalDataUseCase {
 
     private LostPost getLostPostByIdOrDeleteFromEngine(LostAnimalQuery lostAnimalQuery) {
         try {
-            return lostPostDataQueryPort.findLostPostByIdOrThrow(lostAnimalQuery.id());
+            return lostPostDataQueryPort.findActiveLostPostByIdOrThrow(lostAnimalQuery.id());
         } catch (BaseException e) {
             // ES_에서 해당 데이터 삭제 -> ES와 RDB 싱크 맞추기
             // TODO: 현재 함수 구성으로는 FOUND인지 LOST인지 알 수 없어서 둘 다 삭제하게 했습니다...

--- a/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
+++ b/src/main/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataService.java
@@ -53,7 +53,7 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
     @Override
     public LostPostDetailDto findLostPostById(Long lostPostId) {
 
-        LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(lostPostId);
+        LostPost lostPost = lostPostDataQueryPort.findActiveLostPostByIdOrThrow(lostPostId);
         String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
         URL url = imageStoragePort.presignDownload(lostPost.getImageKey(), DOWNLOAD_URL_EXPIRE);
         boolean bookmarked = bookmarkInfoPort.existsByUserIdAndLostPostId(lostPost.getUserId(), lostPost.getLostPostId());
@@ -63,7 +63,7 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
 
     @Override
     public ChatRoomLostPostInfo findChatRoomLostPostInfosById(Long lostPostId) {
-        LostPost lostPost = lostPostDataQueryPort.findLostPostByIdOrThrow(lostPostId);
+        LostPost lostPost = lostPostDataQueryPort.findAnyLostPostByIdOrThrow(lostPostId);
         String author = userInfoPort.getNicknameByUserId(lostPost.getUserId());
         URL imageUrl = imageStoragePort.presignDownload(lostPost.getImageKey(),
                 Duration.ofMinutes(15));
@@ -90,6 +90,6 @@ public class QueryLostPostDataService implements QueryLostPostDataUseCase {
 
     @Override
     public Long getUserIdByLostPostId(Long lostPostId) {
-        return lostPostDataQueryPort.findLostPostByIdOrThrow(lostPostId).getUserId();
+        return lostPostDataQueryPort.findActiveLostPostByIdOrThrow(lostPostId).getUserId();
     }
 }

--- a/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataServiceTest.java
+++ b/src/test/java/kr/co/pawong/pwbe/lostPost/application/service/QueryLostPostDataServiceTest.java
@@ -104,7 +104,7 @@ class QueryLostPostDataServiceTest {
 
         // TODO: 이후 구현
         @Override
-        public LostPost findLostPostByIdOrThrow(Long lostPostId) {
+        public LostPost findActiveLostPostByIdOrThrow(Long lostPostId) {
             if (lostPostId.equals(123L)) {
                 LostPost lp = LostPost.builder()
                         .lostPostId(555L)
@@ -118,6 +118,12 @@ class QueryLostPostDataServiceTest {
                         .build();
                 return lp;
             }
+            return null;
+        }
+
+        // TODO: 이후 구현
+        @Override
+        public LostPost findAnyLostPostByIdOrThrow(Long lostPostId) {
             return null;
         }
 


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/#114 -> develop

### 변경 사항
- soft delete된 lost post 엔티티 조회하는 native query 메소드 추가했습니다.
- 이로 인해 삭제된 공고의 채팅방들도 목록에서 조회되도록 했습니다.

### PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과

