### PR TITLE
[PW-117] 알림 토픽 분리, 토큰 삭제 추가

### DIFF
--- a/src/main/java/kr/co/pawong/pwbe/global/config/KafkaTopicConfig.java
+++ b/src/main/java/kr/co/pawong/pwbe/global/config/KafkaTopicConfig.java
@@ -12,8 +12,10 @@ import org.springframework.kafka.core.KafkaAdmin;
 @Configuration
 public class KafkaTopicConfig {
 
-    @Value("${kafka.topic.fcm-notification}")
-    private String FCM_NOTIFICATION_TOPIC;
+    @Value("${kafka.topic.similar-animal-fcm-notification}")
+    private String SIMILAR_ANIMAL_NOTIFICATION_TOPIC;
+    @Value("${kafka.topic.chat-fcm-notification}")
+    private String CHAT_NOTIFICATION_TOPIC;
     @Value("${kafka.topic.mail-notification}")
     private String MAIL_NOTIFICATION_TOPIC;
     @Value("${kafka.topic.common-dead-letter}")
@@ -79,8 +81,17 @@ public class KafkaTopicConfig {
 
     // fcm 알림
     @Bean
-    public NewTopic fcmNotificationTopic() {
-        return TopicBuilder.name(FCM_NOTIFICATION_TOPIC)
+    public NewTopic similarAnimalNotificationTopic() {
+        return TopicBuilder.name(SIMILAR_ANIMAL_NOTIFICATION_TOPIC)
+                .partitions(1) // 토픽의 파티션 수
+                .replicas(1) // 각 파티션의 복제본 수
+                .build();
+    }
+
+    // fcm 알림
+    @Bean
+    public NewTopic chatNotificationTopic() {
+        return TopicBuilder.name(CHAT_NOTIFICATION_TOPIC)
                 .partitions(1) // 토픽의 파티션 수
                 .replicas(1) // 각 파티션의 복제본 수
                 .build();

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/fcm/adapter/persistence/jpa/FcmAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/fcm/adapter/persistence/jpa/FcmAdapter.java
@@ -40,4 +40,9 @@ public class FcmAdapter implements FcmPort {
         log.debug("사용자 ID로 FCM 토큰 삭제: userId={}", userId);
         fcmRepository.deleteByUserId(userId);
     }
+
+    @Override
+    public void deleteByToken(String token) {
+        fcmRepository.deleteByToken(token);
+    }
 }

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/fcm/adapter/persistence/jpa/repository/FcmRepository.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/fcm/adapter/persistence/jpa/repository/FcmRepository.java
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface FcmRepository extends JpaRepository<FcmTokenEntity, Long> {
     Optional<FcmTokenEntity> findByUserId(Long userId);
     void deleteByUserId(Long userId);
+    void deleteByToken(String token);
 }

--- a/src/main/java/kr/co/pawong/pwbe/infrastructure/fcm/application/port/out/FcmPort.java
+++ b/src/main/java/kr/co/pawong/pwbe/infrastructure/fcm/application/port/out/FcmPort.java
@@ -6,5 +6,5 @@ public interface FcmPort {
     void save(FcmToken fcmToken);
     FcmToken findByUserId(Long userId);
     void deleteByUserId(Long userId);
-
+    void deleteByToken(String token);
 }

--- a/src/main/java/kr/co/pawong/pwbe/notification/adapter/in/messaging/KafkaMessageConsumer.java
+++ b/src/main/java/kr/co/pawong/pwbe/notification/adapter/in/messaging/KafkaMessageConsumer.java
@@ -16,10 +16,19 @@ public class KafkaMessageConsumer {
     private final MailUseCase mailUseCase;
 
     @KafkaListener(
-            topics = "${kafka.topic.fcm-notification}",
+            topics = "${kafka.topic.similar-animal-fcm-notification}",
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumeSimilarAnimalNotificationMessage(String jsonString) {
+        log.info("[유사 공고 알림] 메시지 수신: {}", jsonString);
+        notificationUseCase.processFcmNotificationMessage(jsonString);
+    }
+
+    @KafkaListener(
+            topics = "${kafka.topic.chat-fcm-notification}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumeChatNotificationMessage(String jsonString) {
         notificationUseCase.processFcmNotificationMessage(jsonString);
     }
 
@@ -27,7 +36,7 @@ public class KafkaMessageConsumer {
             topics = "${kafka.topic.mail-notification}",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void consumeChatNotificationMessage(String jsonString) {
+    public void consumeMailNotificationMessage(String jsonString) {
         mailUseCase.processMailNotificationMessage(jsonString);
     }
 }

--- a/src/main/java/kr/co/pawong/pwbe/notification/adapter/out/persistence/jpa/NotificationAdapter.java
+++ b/src/main/java/kr/co/pawong/pwbe/notification/adapter/out/persistence/jpa/NotificationAdapter.java
@@ -10,6 +10,7 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushNotification;
 import kr.co.pawong.pwbe.global.error.exception.BaseException;
+import kr.co.pawong.pwbe.infrastructure.fcm.application.port.out.FcmPort;
 import kr.co.pawong.pwbe.notification.adapter.out.persistence.jpa.entity.NotificationEntity;
 import kr.co.pawong.pwbe.notification.adapter.out.persistence.jpa.repository.NotificationJpaRepository;
 import kr.co.pawong.pwbe.notification.application.port.out.NotificationPort;
@@ -26,6 +27,7 @@ public class NotificationAdapter implements NotificationPort {
 
     private final NotificationJpaRepository notificationJpaRepository;
     private final FirebaseMessaging firebaseMessaging;
+    private final FcmPort fcmPort;
 
     @Override
     public Notification save(Notification notification) {
@@ -94,6 +96,10 @@ public class NotificationAdapter implements NotificationPort {
         } catch (FirebaseMessagingException e) {
             log.error("FCM 알림 전송 실패: notificationId={}, error={}",
                     notificationDto.getId(), e.getMessage(), e);
+            if (e.getErrorCode() != null && e.getErrorCode().equals("UNREGISTERED")) {
+                fcmPort.deleteByToken(notificationDto.getToken()); // 토큰 삭제
+            }
+            log.error("토큰을 삭제하였습니다!");
             throw new BaseException(NOTIFICATION_SEND_ERROR);
         } catch (Exception e) {
             log.error("알림 처리 중 예상치 못한 오류 발생: notificationId={}",

--- a/src/main/java/kr/co/pawong/pwbe/notification/application/service/NotificationService.java
+++ b/src/main/java/kr/co/pawong/pwbe/notification/application/service/NotificationService.java
@@ -33,8 +33,12 @@ public class NotificationService implements NotificationUseCase {
     private final NotificationUtils notificationUtils;
 
     // fcm 메시지를 발행할 kafka 토픽 이름
-    @Value("${kafka.topic.fcm-notification}")
-    private String fcmNotificationTopic;
+    @Value("${kafka.topic.similar-animal-fcm-notification}")
+    private String similarAnimalNotificationTopic;
+
+    // fcm 메시지를 발행할 kafka 토픽 이름
+    @Value("${kafka.topic.chat-fcm-notification}")
+    private String chatNotificationTopic;
 
 
     // 채팅 알림
@@ -64,7 +68,7 @@ public class NotificationService implements NotificationUseCase {
 
             // NotificationDto로 변환하여 Kafka에 발행
             NotificationDto notificationDto = savedNotification.toDto(token);
-            publishMessageUseCase.publishMessage(fcmNotificationTopic, notificationDto);
+            publishMessageUseCase.publishMessage(chatNotificationTopic, notificationDto);
 
             log.info("채팅 알림 발송 완료: userId={}, id={}", request.getUserId(), savedNotification.getId());
 
@@ -101,7 +105,7 @@ public class NotificationService implements NotificationUseCase {
 
             // NotificationDto로 변환하여 Kafka에 발행
             NotificationDto notificationDto = savedNotification.toDto(token);
-            publishMessageUseCase.publishMessage(fcmNotificationTopic, notificationDto);
+            publishMessageUseCase.publishMessage(similarAnimalNotificationTopic, notificationDto);
 
             log.info("유사 공고 알림 발송 완료: userId={}, id={}", request.getUserId(), savedNotification.getId());
         } catch (BaseException e) {

--- a/src/main/resources/config/kafka.yml
+++ b/src/main/resources/config/kafka.yml
@@ -17,7 +17,8 @@ spring:
       ack-mode: record
 kafka:
   topic:
-    fcm-notification: "dev.pawong.notification.fcm"
+    similar-animal-fcm-notification: "dev.pawong.notification.similar-animal.fcm"
+    chat-fcm-notification: "dev.pawong.notification.chat.fcm"
     mail-notification: "dev.pawong.notification.mail"
     common-dead-letter: "dev.pawong.common.dlt"
     lost-post-created: "dev.pawong.lost-post.created"


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#117 -> develop

### 변경 사항
- FCM 알림 토픽을 유사공고, 채팅으로 분리했습니다.
- 오류났을때 토큰을 삭제하는 로직을 추가했습니다.

### PR 체크리스트
- [ ] 테스트는 모두 통과했나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] PR 내부의 예시는 삭제하셨나요?

### 테스트 결과

